### PR TITLE
improve set input detection - fixes #8

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,13 @@ class Conf {
 		return dotProp.get(this.store, key);
 	}
 	set(key, val) {
+		if (typeof key !== 'string' && typeof key !== 'object') {
+			throw new TypeError(`Expected \`key\` to be of type \`string\` or \`object\`, got ${typeof key}`);
+		}
+
 		const store = this.store;
 
-		if (val === undefined) {
+		if (typeof key === 'object') {
 			Object.keys(key).forEach(k => {
 				dotProp.set(store, k, key[k]);
 			});

--- a/test.js
+++ b/test.js
@@ -43,6 +43,10 @@ test('.set() with object', t => {
 	t.is(t.context.conf.get('baz.foo.bar'), 'baz');
 });
 
+test('.set() invalid key', t => {
+	t.throws(() => t.context.conf.set(1, 'unicorn'), 'Expected `key` to be of type `string` or `object`, got number');
+});
+
 test('.has()', t => {
 	t.context.conf.set('foo', fixture);
 	t.context.conf.set('baz.boo', fixture);


### PR DESCRIPTION
Things I missed?

Should we also check `if (typeof key === 'string' && val === undefined)` and throw an error? Or should we allow to overwrite a value with `undefined`? Seems a valid use case...