### PR TITLE
Add support for providing a default value with getter

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ class Conf {
 		this.path = path.resolve(opts.cwd, `${opts.configName}.json`);
 		this.store = Object.assign(obj(), opts.defaults, this.store);
 	}
-	get(key) {
-		return dotProp.get(this.store, key);
+	get(key, defaultValue) {
+		return dotProp.get(this.store, key, defaultValue);
 	}
 	set(key, val) {
 		if (typeof key !== 'string' && typeof key !== 'object') {

--- a/readme.md
+++ b/readme.md
@@ -90,9 +90,9 @@ Set an item.
 
 Set multiple items at once.
 
-#### .get(key)
+#### .get(key, [defaultValue])
 
-Get an item.
+Get an item or `defaultValue` if the item does not exist.
 
 #### .has(key)
 

--- a/test.js
+++ b/test.js
@@ -13,6 +13,7 @@ test.beforeEach(t => {
 
 test('.get()', t => {
 	t.is(t.context.conf.get('foo'), undefined);
+	t.is(t.context.conf.get('foo', '🐴'), '🐴');
 	t.context.conf.set('foo', fixture);
 	t.is(t.context.conf.get('foo'), fixture);
 });


### PR DESCRIPTION
The `4.x` version of `dot-prop` includes the ability to pass a default with the `.get()` function which will be returned if the property is not defined. I am using your module `electron-config` and would like this functionality included for the added convenience of setting a default configuration state when one has not been saved for the user.