### PR TITLE
Fix #11 by falling back to cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,16 +13,10 @@ delete require.cache[__filename];
 class Conf {
 	constructor(opts) {
 		let pkgPath;
-		// Fallback to current package.json if module.parent.filename is null (f.e. in REPL)
 		if (module.parent.filename) {
 			pkgPath = pkgUp.sync(path.dirname(module.parent.filename));
 		} else {
-			pkgPath = path.join(__dirname, 'package.json');
-			try {
-				fs.accessSync(pkgPath, fs.constants.F_OK | fs.constants.R_OK);
-			} catch (err) {
-				pkgPath = null;
-			}
+			pkgPath = pkgUp.sync(process.cwd());
 		}
 
 		opts = Object.assign({

--- a/index.js
+++ b/index.js
@@ -10,11 +10,20 @@ const obj = () => Object.create(null);
 
 // Prevent caching of this module so module.parent is always accurate
 delete require.cache[__filename];
-const parentDir = path.dirname(module.parent.filename);
-
 class Conf {
 	constructor(opts) {
-		const pkgPath = pkgUp.sync(parentDir);
+		let pkgPath;
+		// Fallback to current package.json if module.parent.filename is null (f.e. in REPL)
+		if (module.parent.filename) {
+			pkgPath = pkgUp.sync(path.dirname(module.parent.filename));
+		} else {
+			pkgPath = path.join(__dirname, 'package.json');
+			try {
+				fs.accessSync(pkgPath, fs.constants.F_OK | fs.constants.R_OK);
+			} catch (err) {
+				pkgPath = null;
+			}
+		}
 
 		opts = Object.assign({
 			// If the package.json was not found, avoid breaking with `require(null)`

--- a/index.js
+++ b/index.js
@@ -12,12 +12,7 @@ const obj = () => Object.create(null);
 delete require.cache[__filename];
 class Conf {
 	constructor(opts) {
-		let pkgPath;
-		if (module.parent.filename) {
-			pkgPath = pkgUp.sync(path.dirname(module.parent.filename));
-		} else {
-			pkgPath = pkgUp.sync(process.cwd());
-		}
+		const pkgPath = pkgUp.sync(path.dirname(module.parent.filename || '.'));
 
 		opts = Object.assign({
 			// If the package.json was not found, avoid breaking with `require(null)`

--- a/index.js
+++ b/index.js
@@ -10,9 +10,10 @@ const obj = () => Object.create(null);
 
 // Prevent caching of this module so module.parent is always accurate
 delete require.cache[__filename];
+const parentDir = path.dirname(module.parent.filename || '.');
 class Conf {
 	constructor(opts) {
-		const pkgPath = pkgUp.sync(path.dirname(module.parent.filename || '.'));
+		const pkgPath = pkgUp.sync(parentDir);
 
 		opts = Object.assign({
 			// If the package.json was not found, avoid breaking with `require(null)`

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const obj = () => Object.create(null);
 // Prevent caching of this module so module.parent is always accurate
 delete require.cache[__filename];
 const parentDir = path.dirname(module.parent.filename || '.');
+
 class Conf {
 	constructor(opts) {
 		const pkgPath = pkgUp.sync(parentDir);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "clear-require": "^2.0.0",
     "del": "^2.2.1",
     "tempfile": "^1.1.1",
     "xo": "*"

--- a/test.js
+++ b/test.js
@@ -195,7 +195,7 @@ test('handle `cwd` being set and `projectName` not being set', t => {
 });
 
 // See https://github.com/sindresorhus/conf/issues/11
-test('fallback to `__dirname` if `module.filname` is `null`', t => {
+test('fallback to `process.cwd` if `module.filename` is `null`', t => {
 	const pkgUpSyncOrig = pkgUp.sync;
 	pkgUp.sync = () => null;
 

--- a/test.js
+++ b/test.js
@@ -196,6 +196,7 @@ test('handle `cwd` being set and `projectName` not being set', t => {
 
 // See https://github.com/sindresorhus/conf/issues/11
 test('fallback to cwd if `module.filename` is `null`', t => {
+	const preservedFilename = module.filename;
 	module.filename = null;
 
 	let conf;
@@ -203,5 +204,6 @@ test('fallback to cwd if `module.filename` is `null`', t => {
 		conf = new Conf();
 	});
 
+	module.filename = preservedFilename;
 	del.sync(conf.path, {force: true});
 });

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ import {serial as test} from 'ava';
 import tempfile from 'tempfile';
 import del from 'del';
 import pkgUp from 'pkg-up';
+import clearRequire from 'clear-require';
 import Conf from './';
 
 const fixture = '🦄';
@@ -198,10 +199,11 @@ test('handle `cwd` being set and `projectName` not being set', t => {
 test('fallback to cwd if `module.filename` is `null`', t => {
 	const preservedFilename = module.filename;
 	module.filename = null;
+	clearRequire('./');
 
 	let conf;
 	t.notThrows(() => {
-		conf = new Conf();
+		conf = require('./');
 	});
 
 	module.filename = preservedFilename;

--- a/test.js
+++ b/test.js
@@ -193,3 +193,19 @@ test('handle `cwd` being set and `projectName` not being set', t => {
 	del.sync(conf.path, {force: true});
 	pkgUp.sync = pkgUpSyncOrig;
 });
+
+// See https://github.com/sindresorhus/conf/issues/11
+test('fallback to `__dirname` if `module.filname` is `null`', t => {
+	const pkgUpSyncOrig = pkgUp.sync;
+	pkgUp.sync = () => null;
+
+	module.filename = null;
+
+	let conf;
+	t.notThrows(() => {
+		conf = new Conf();
+	});
+
+	del.sync(conf.path, {force: true});
+	pkgUp.sync = pkgUpSyncOrig;
+});

--- a/test.js
+++ b/test.js
@@ -195,7 +195,7 @@ test('handle `cwd` being set and `projectName` not being set', t => {
 });
 
 // See https://github.com/sindresorhus/conf/issues/11
-test('fallback to `process.cwd` if `module.filename` is `null`', t => {
+test('fallback to cwd if `module.filename` is `null`', t => {
 	const pkgUpSyncOrig = pkgUp.sync;
 	pkgUp.sync = () => null;
 

--- a/test.js
+++ b/test.js
@@ -196,9 +196,6 @@ test('handle `cwd` being set and `projectName` not being set', t => {
 
 // See https://github.com/sindresorhus/conf/issues/11
 test('fallback to cwd if `module.filename` is `null`', t => {
-	const pkgUpSyncOrig = pkgUp.sync;
-	pkgUp.sync = () => null;
-
 	module.filename = null;
 
 	let conf;
@@ -207,5 +204,4 @@ test('fallback to cwd if `module.filename` is `null`', t => {
 	});
 
 	del.sync(conf.path, {force: true});
-	pkgUp.sync = pkgUpSyncOrig;
 });

--- a/test.js
+++ b/test.js
@@ -195,15 +195,15 @@ test('handle `cwd` being set and `projectName` not being set', t => {
 	pkgUp.sync = pkgUpSyncOrig;
 });
 
-// See https://github.com/sindresorhus/conf/issues/11
+// See #11
 test('fallback to cwd if `module.filename` is `null`', t => {
 	const preservedFilename = module.filename;
 	module.filename = null;
-	clearRequire('./');
+	clearRequire('.');
 
 	let conf;
 	t.notThrows(() => {
-		conf = require('./');
+		conf = require('.');
 	});
 
 	module.filename = preservedFilename;


### PR DESCRIPTION
The usage of conf fails in the REPL environment because the `module.filename` is `null`. In order to play around with the current module's config, i added the search & use of a local `package.json` if it exists.