### PR TITLE
Check if data is unencrypted before encrypting

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,12 @@ class Conf {
 			let data = fs.readFileSync(this.path, this.encryptionKey ? null : 'utf8');
 
 			if (this.encryptionKey) {
-				const decipher = crypto.createDecipher('aes-256-cbc', this.encryptionKey);
-				data = Buffer.concat([decipher.update(data), decipher.final()]);
+				try {
+					return Object.assign(obj(), JSON.parse(data));
+				} catch (err) {
+					const decipher = crypto.createDecipher('aes-256-cbc', this.encryptionKey);
+					data = Buffer.concat([decipher.update(data), decipher.final()]);
+				}
 			}
 
 			return Object.assign(obj(), JSON.parse(data));

--- a/index.js
+++ b/index.js
@@ -110,8 +110,12 @@ class Conf {
 				try {
 					return Object.assign(obj(), JSON.parse(data));
 				} catch (err) {
-					const decipher = crypto.createDecipher('aes-256-cbc', this.encryptionKey);
-					data = Buffer.concat([decipher.update(data), decipher.final()]);
+					try {
+						const decipher = crypto.createDecipher('aes-256-cbc', this.encryptionKey);
+						data = Buffer.concat([decipher.update(data), decipher.final()]);
+					} catch (err) {
+						return obj();
+					}
 				}
 			}
 

--- a/index.js
+++ b/index.js
@@ -108,15 +108,9 @@ class Conf {
 
 			if (this.encryptionKey) {
 				try {
-					return Object.assign(obj(), JSON.parse(data));
-				} catch (err) {
-					try {
-						const decipher = crypto.createDecipher('aes-256-cbc', this.encryptionKey);
-						data = Buffer.concat([decipher.update(data), decipher.final()]);
-					} catch (err) {
-						return obj();
-					}
-				}
+					const decipher = crypto.createDecipher('aes-256-cbc', this.encryptionKey);
+					data = Buffer.concat([decipher.update(data), decipher.final()]);
+				} catch (err) {/* ignore */}
 			}
 
 			return Object.assign(obj(), JSON.parse(data));

--- a/test.js
+++ b/test.js
@@ -221,6 +221,17 @@ test('encryption', t => {
 	t.is(conf.get('baz.boo'), fixture);
 });
 
+test('encryption - upgrade', t => {
+	const cwd = tempy.directory();
+
+	const before = new Conf({cwd});
+	before.set('foo', fixture);
+	t.is(before.get('foo'), fixture);
+
+	const after = new Conf({cwd, encryptionKey: 'abc123'});
+	t.is(after.get('foo'), fixture);
+});
+
 test('onDidChange()', t => {
 	const conf = t.context.conf;
 

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import {serial as test} from 'ava';
 import tempy from 'tempy';
@@ -230,6 +231,19 @@ test('encryption - upgrade', t => {
 
 	const after = new Conf({cwd, encryptionKey: 'abc123'});
 	t.is(after.get('foo'), fixture);
+});
+
+test('encryption - corrupt file', t => {
+	const cwd = tempy.directory();
+
+	const before = new Conf({cwd, encryptionKey: 'abc123'});
+	before.set('foo', fixture);
+	t.is(before.get('foo'), fixture);
+
+	fs.appendFileSync(path.join(cwd, 'config.json'), 'corrupt file');
+
+	const after = new Conf({cwd, encryptionKey: 'abc123'});
+	t.is(after.get('foo'), undefined);
 });
 
 test('onDidChange()', t => {


### PR DESCRIPTION
For the issue raised in #21.

I think this solution is simple enough:

- Try to parse and return the data. If not, try and decrypt it.
- If decrypting fails, act the same as before (as if the file didn't exist, or there was a `SyntaxError`).
- Otherwise, if parsing worked - just continue as normal.

So, notable changes:

1. Users can now set `encryptionKey` without worrying about upgrading the store
2. If decryption fails, `Conf` will silently just return the defaults