### PR TITLE
Recommend `.delete()` when setting `undefined`

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,10 @@ class Conf {
 			throw new TypeError(`Expected \`key\` to be of type \`string\` or \`object\`, got ${typeof key}`);
 		}
 
+		if (typeof key !== 'object' && val === undefined) {
+			throw new TypeError('Use `delete()` to clear values');
+		}
+
 		const store = this.store;
 
 		if (typeof key === 'object') {

--- a/test.js
+++ b/test.js
@@ -46,6 +46,10 @@ test('.set() with object', t => {
 	t.is(t.context.conf.get('baz.foo.bar'), 'baz');
 });
 
+test('.set() with undefined', t => {
+	t.throws(() => t.context.conf.set('foo', undefined), 'Use `delete()` to clear values');
+});
+
 test('.set() invalid key', t => {
 	t.throws(() => t.context.conf.set(1, 'unicorn'), 'Expected `key` to be of type `string` or `object`, got number');
 });


### PR DESCRIPTION
Fixes #25.

Not satisfied with the error message + type of error being thrown, but here's a first pass at solving the issue.