### PR TITLE
Avoiding always writing to disk upon instantiation

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,14 @@ class Conf {
 		this.events = new EventEmitter();
 		this.encryptionKey = options.encryptionKey;
 		this.path = path.resolve(options.cwd, `${options.configName}.json`);
-		this.store = Object.assign(plainObject(), options.defaults, this.store);
+
+		const fileStore = this.store;
+		const store = Object.assign(plainObject(), options.defaults, this.store);
+		try {
+			assert.deepEqual(fileStore, store);
+		} catch (e) {
+			this.store = store;
+		}
 	}
 
 	get(key, defaultValue) {

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ class Conf {
 		this.path = path.resolve(options.cwd, `${options.configName}.json`);
 
 		const fileStore = this.store;
-		const store = Object.assign(plainObject(), options.defaults, this.store);
+		const store = Object.assign(plainObject(), options.defaults, fileStore);
 		try {
 			assert.deepEqual(fileStore, store);
 		} catch (e) {

--- a/test.js
+++ b/test.js
@@ -294,3 +294,18 @@ test('onDidChange()', t => {
 	unsubscribe();
 	conf.set('foo', fixture);
 });
+
+// See #32
+test('doesn\'t write to disk upon instanciation if and only if the store didn\'t change', t => {
+	let exists = fs.existsSync(t.context.conf.path);
+	t.is(exists, false);
+
+	const conf = new Conf({
+		cwd: tempy.directory(),
+		defaults: {
+			foo: 'bar'
+		}
+	});
+	exists = fs.existsSync(conf.path);
+	t.is(exists, true);
+});


### PR DESCRIPTION
Fixes #32.

A couple of things worth noting:

- that `assert.deepEqual` call may be expensive, but hopefully less expensive than a file write.
- if a `new Conf` is instantiated, without any default properties, `conf.path` won't exist until `conf.set` is called. 