### PR TITLE
Make the config file private to its owner

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ class Conf {
 			data = Buffer.concat([cipher.update(Buffer.from(data)), cipher.final()]);
 		}
 
-		writeFileAtomic.sync(this.path, data);
+		writeFileAtomic.sync(this.path, data, {mode: 0o600});
 		this.events.emit('change');
 	}
 


### PR DESCRIPTION
The current permissions on the config file allows other users on the system to read the data (0o644).

It's worth throwing away the read permissions for group and public.