### PR TITLE
Add `projectSuffix` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,6 @@ class Conf {
 		options = Object.assign({
 			configName: 'config',
 			fileExtension: 'json',
-			// Maintain behaviour of 2.0.0 for the new option
 			projectSuffix: 'nodejs'
 		}, options);
 

--- a/index.js
+++ b/index.js
@@ -33,11 +33,13 @@ class Conf {
 
 		options = Object.assign({
 			configName: 'config',
-			fileExtension: 'json'
+			fileExtension: 'json',
+			// Maintain behaviour of 2.0.0 for the new option
+			projectSuffix: 'nodejs'
 		}, options);
 
 		if (!options.cwd) {
-			options.cwd = envPaths(options.projectName).config;
+			options.cwd = envPaths(options.projectName, {suffix: options.projectSuffix}).config;
 		}
 
 		this.events = new EventEmitter();

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,63 @@ Default: The `name` field in the package.json closest to where `conf` is importe
 
 You only need to specify this if you don't have a package.json file in your project.
 
+#### projectSuffix
+
+Type: `string`<br>
+Default: `nodejs`
+
+Suffix to be added to `projectName` during config file creation.
+
+You can pass an empty string in order to disable any suffixes at all.
+
+##### Examples
+
+Every example in this subsection is supposedly used in a project called `test-project`.
+
+**Default option**
+
+```js
+const conf = new Conf();
+```
+
+The config file will be placed in the following subtree:
+```
+$OS_SPECIFIC_PATH
+├─── test-project-nodejs
+|   └─── Config
+|       └─── config.json
+```
+
+**Empty string option**
+
+```js
+const projectSuffix = '';
+const conf = new Conf({projectSuffix});
+```
+
+The config file will be placed in the following subtree:
+```
+$OS_SPECIFIC_PATH
+├─── test-project // <--- Here! No '-nodejs' suffix!
+|   └─── Config
+|       └─── config.json
+```
+
+**Custom string option**
+
+```js
+const projectSuffix = 'custom';
+const conf = new Conf({projectSuffix});
+```
+
+The config file will be placed in the following subtree:
+```
+$OS_SPECIFIC_PATH
+├─── test-project-custom // <--- Here! We have our very own '-custom' suffix!
+|   └─── Config
+|       └─── config.json
+```
+
 #### cwd
 
 Type: `string`<br>

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ You can pass an empty string in order to disable any suffixes at all.
 
 Every example in this subsection is supposedly used in a project called `test-project`.
 
-**Default option**
+###### Default option
 
 ```js
 const conf = new Conf();
@@ -101,7 +101,7 @@ $OS_SPECIFIC_PATH
 |       └─── config.json
 ```
 
-**Empty string option**
+###### Empty string option
 
 ```js
 const projectSuffix = '';
@@ -116,7 +116,7 @@ $OS_SPECIFIC_PATH
 |       └─── config.json
 ```
 
-**Custom string option**
+###### Custom string option
 
 ```js
 const projectSuffix = 'custom';

--- a/readme.md
+++ b/readme.md
@@ -97,8 +97,7 @@ The config file will be placed in the following subtree:
 ```
 $OS_SPECIFIC_PATH
 ├─── test-project-nodejs
-|   └─── Config
-|       └─── config.json
+|   └─── $OS_SPECIFIC_CONFIG
 ```
 
 ###### Empty string option
@@ -112,8 +111,7 @@ The config file will be placed in the following subtree:
 ```
 $OS_SPECIFIC_PATH
 ├─── test-project // <--- Here! No '-nodejs' suffix!
-|   └─── Config
-|       └─── config.json
+|   └─── $OS_SPECIFIC_CONFIG
 ```
 
 #### cwd

--- a/readme.md
+++ b/readme.md
@@ -74,46 +74,6 @@ Default: The `name` field in the package.json closest to where `conf` is importe
 
 You only need to specify this if you don't have a package.json file in your project.
 
-#### projectSuffix
-
-Type: `string`<br>
-Default: `nodejs`
-
-Suffix appended to `projectName` during config file creation to avoid name conflicts with native apps.
-
-You can pass an empty string in order to disable any suffixes at all.
-
-##### Examples
-
-Every example in this subsection is supposedly used in a project called `test-project`.
-
-###### Default option
-
-```js
-const conf = new Conf();
-```
-
-The config file will be placed in the following subtree:
-```
-$OS_SPECIFIC_PATH
-├─── test-project-nodejs
-|   └─── $OS_SPECIFIC_CONFIG
-```
-
-###### Empty string option
-
-```js
-const projectSuffix = '';
-const conf = new Conf({projectSuffix});
-```
-
-The config file will be placed in the following subtree:
-```
-$OS_SPECIFIC_PATH
-├─── test-project // <--- Here! No '-nodejs' suffix!
-|   └─── $OS_SPECIFIC_CONFIG
-```
-
 #### cwd
 
 Type: `string`<br>
@@ -146,6 +106,19 @@ Default: `json`
 Extension of the config file.
 
 You would usually not need this, but could be useful if you want to interact with a file with a custom file extension that can be associated with your app. These might be simple save/export/preference files that are intended to be shareable or saved outside of the app.
+
+#### projectSuffix
+
+Type: `string`<br>
+Default: `nodejs`
+
+**You most likely don't need this. Please don't use it unless you really have to.**
+
+Suffix appended to `projectName` during config file creation to avoid name conflicts with native apps.
+
+You can pass an empty string to remove the suffix.
+
+For example, on macOS, the config file will be stored in the `~/Library/Preferences/foo-nodejs` directory, where `foo` is the `projectName`.
 
 ### Instance
 

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ You only need to specify this if you don't have a package.json file in your proj
 Type: `string`<br>
 Default: `nodejs`
 
-Suffix to be added to `projectName` during config file creation.
+Suffix appended to `projectName` during config file creation to avoid name conflicts with native apps.
 
 You can pass an empty string in order to disable any suffixes at all.
 
@@ -112,21 +112,6 @@ The config file will be placed in the following subtree:
 ```
 $OS_SPECIFIC_PATH
 ├─── test-project // <--- Here! No '-nodejs' suffix!
-|   └─── Config
-|       └─── config.json
-```
-
-###### Custom string option
-
-```js
-const projectSuffix = 'custom';
-const conf = new Conf({projectSuffix});
-```
-
-The config file will be placed in the following subtree:
-```
-$OS_SPECIFIC_PATH
-├─── test-project-custom // <--- Here! We have our very own '-custom' suffix!
 |   └─── Config
 |       └─── config.json
 ```

--- a/test.js
+++ b/test.js
@@ -128,8 +128,7 @@ test('`configName` option', t => {
 
 test('no `suffix` option', t => {
 	const conf = new Conf();
-	// Maintain behaviour of 2.0.0
-	t.true(conf.path.includes('-node'));
+	t.true(conf.path.includes('-nodejs'));
 });
 
 test('with `suffix` option set to empty string', t => {

--- a/test.js
+++ b/test.js
@@ -126,6 +126,30 @@ test('`configName` option', t => {
 	t.is(path.basename(conf.path, '.json'), configName);
 });
 
+test('no `suffix` option', t => {
+	const conf = new Conf();
+	// Maintain behaviour of 2.0.0
+	t.true(conf.path.includes('-node'));
+});
+
+test('with `suffix` option set to empty string', t => {
+	const projectSuffix = '';
+	const conf = new Conf({projectSuffix});
+	// Config file's directory root
+	const configRoot = path.resolve(conf.path, '../..');
+	// Extract the config file's parent folder
+	const rootName = path.basename(configRoot);
+	// Expect to not have the path
+	t.false(rootName.includes(`-${projectSuffix}`));
+});
+
+test('with `projectSuffix` option set to non-empty string', t => {
+	const projectSuffix = 'new-projectSuffix';
+	const conf = new Conf({projectSuffix});
+	// New option starting from 2.0.0 (excluded)
+	t.true(conf.path.includes(`-${projectSuffix}`));
+});
+
 test('`fileExtension` option', t => {
 	const fileExtension = 'alt-ext';
 	const conf = new Conf({

--- a/test.js
+++ b/test.js
@@ -135,18 +135,14 @@ test('no `suffix` option', t => {
 test('with `suffix` option set to empty string', t => {
 	const projectSuffix = '';
 	const conf = new Conf({projectSuffix});
-	// Config file's directory root
 	const configRoot = path.resolve(conf.path, '../..');
-	// Extract the config file's parent folder
 	const rootName = path.basename(configRoot);
-	// Expect to not have the path
 	t.false(rootName.includes(`-${projectSuffix}`));
 });
 
 test('with `projectSuffix` option set to non-empty string', t => {
 	const projectSuffix = 'new-projectSuffix';
 	const conf = new Conf({projectSuffix});
-	// New option starting from 2.0.0 (excluded)
 	t.true(conf.path.includes(`-${projectSuffix}`));
 });
 

--- a/test.js
+++ b/test.js
@@ -133,16 +133,21 @@ test('no `suffix` option', t => {
 
 test('with `suffix` option set to empty string', t => {
 	const projectSuffix = '';
-	const conf = new Conf({projectSuffix});
-	const configRoot = path.resolve(conf.path, '../..');
-	const rootName = path.basename(configRoot);
-	t.false(rootName.includes(`-${projectSuffix}`));
+	const projectName = 'conf-temp1-project';
+	const conf = new Conf({projectSuffix, projectName});
+	const configPathSegments = conf.path.split(path.sep);
+	const configRootIndex = configPathSegments.findIndex(segment => segment === projectName);
+	t.true(configRootIndex >= 0 && configRootIndex < configPathSegments.length);
 });
 
 test('with `projectSuffix` option set to non-empty string', t => {
 	const projectSuffix = 'new-projectSuffix';
-	const conf = new Conf({projectSuffix});
-	t.true(conf.path.includes(`-${projectSuffix}`));
+	const projectName = 'conf-temp2-project';
+	const conf = new Conf({projectSuffix, projectName});
+	const configPathSegments = conf.path.split(path.sep);
+	const expectedRootName = `${projectName}-${projectSuffix}`;
+	const configRootIndex = configPathSegments.findIndex(segment => segment === expectedRootName);
+	t.true(configRootIndex >= 0 && configRootIndex < configPathSegments.length);
 });
 
 test('`fileExtension` option', t => {


### PR DESCRIPTION
Since #35 is still open, I thought I could finally resolve it maintaining the current behavior (as of 2.0.0) of adding the 'nodejs' suffix by default.

The option for controlling it is called `projectSuffix`, but feel free to change it to something you think is more appropriate.

I added 3 test cases which should cover all the cases I thought of:

1. **compatibility**: maintain the 2.0.0 behavior when not specifying the `projectSuffix`, so it will add the 'nodejs' suffix;
2. **new**: specifying an empty string should disable the suffix;
3. **new**: specifying a custom suffix should just use it instead of 'nodejs'.

I also updated the README with the new option specifics (added an `Examples` subsection).

---

Fixes #35