### PR TITLE
If extension was not set do not include the dot

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ class Conf {
 		this.encryptionKey = options.encryptionKey;
 
 		const fileExtension = options.fileExtension ? `.${options.fileExtension}` : '';
-		this.path = path.resolve(options.cwd, `${options.configName}${fileExtension}`);
+		this.path = (options.fileExtension) ? path.resolve(options.cwd, `${options.configName}.${options.fileExtension}`) 
+			: path.resolve(options.cwd, options.configName);
 
 		const fileStore = this.store;
 		const store = Object.assign(plainObject(), options.defaults, fileStore);


### PR DESCRIPTION
If I want to use the config without an extension I can't do it. Because the dot includes in a final path.