### PR TITLE
Check that require.cache exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ const writeFileAtomic = require('write-file-atomic');
 const plainObject = () => Object.create(null);
 
 // Prevent caching of this module so module.parent is always accurate
-delete require.cache[__filename];
+if (require.cache) {
+	delete require.cache[__filename];
+}
 const parentDir = path.dirname((module.parent && module.parent.filename) || '.');
 
 class Conf {


### PR DESCRIPTION
Make sure require.cache exists before trying to alter it. This fixes an 'undefined' error when building with nexe.