### PR TITLE
Add `onDidAnyChange` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,11 @@ class Conf {
 		};
 
 		this.events.on('change', onChange);
-		return () => this.events.removeListener('change', onChange);
+		
+		// TODO: Use `this.events.off` when targeting Node.js 10
+		return () => {
+			this.events.removeListener('change', onChange);
+		};
 	}
 
 	onDidChange(key, callback) {

--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,12 @@ Delete all items.
 
 Watches the given `key`, calling `callback` on any changes. When a key is first set `oldValue` will be `undefined`, and when a key is deleted `newValue` will be `undefined`.
 
+#### .onDidAnyChange(callback)
+
+`callback`: `(newValue, oldValue) => {}`
+
+Calls `callback` on changes anywhere in the config file. `oldValue` and `newValue` will be the full config object before after the change, respectively. You must compare `oldValue` to `newValue` to find out what changed.
+
 #### .size
 
 Get the item count.

--- a/test.js
+++ b/test.js
@@ -317,7 +317,6 @@ test('onDidChange()', t => {
 	conf.set('foo', fixture);
 });
 
-// See #45
 test('onDidAnyChange()', t => {
 	const {conf} = t.context;
 

--- a/test.js
+++ b/test.js
@@ -317,6 +317,70 @@ test('onDidChange()', t => {
 	conf.set('foo', fixture);
 });
 
+// See #45
+test('onDidAnyChange()', t => {
+	const {conf} = t.context;
+
+	t.plan(8);
+
+	const checkFoo = (newValue, oldValue) => {
+		t.deepEqual(newValue, {foo: '🐴'});
+		t.deepEqual(oldValue, {foo: fixture});
+	};
+
+	const checkBaz = (newValue, oldValue) => {
+		t.deepEqual(newValue, {
+			foo: fixture,
+			baz: {boo: '🐴'}
+		});
+		t.deepEqual(oldValue, {
+			foo: fixture,
+			baz: {boo: fixture}
+		});
+	};
+
+	conf.set('foo', fixture);
+	let unsubscribe = conf.onDidAnyChange(checkFoo);
+	conf.set('foo', '🐴');
+	unsubscribe();
+	conf.set('foo', fixture);
+
+	conf.set('baz.boo', fixture);
+	unsubscribe = conf.onDidAnyChange(checkBaz);
+	conf.set('baz.boo', '🐴');
+	unsubscribe();
+	conf.set('baz.boo', fixture);
+
+	const checkUndefined = (newValue, oldValue) => {
+		t.deepEqual(oldValue, {
+			foo: '🦄',
+			baz: {boo: '🦄'}
+		});
+
+		t.deepEqual(newValue, {
+			baz: {boo: fixture}
+		});
+	};
+	const checkSet = (newValue, oldValue) => {
+		t.deepEqual(oldValue, {
+			baz: {boo: fixture}
+		});
+
+		t.deepEqual(newValue, {
+			baz: {boo: '🦄'},
+			foo: '🐴'
+		});
+	};
+
+	unsubscribe = conf.onDidAnyChange(checkUndefined);
+	conf.delete('foo');
+	unsubscribe();
+	unsubscribe = conf.onDidAnyChange(checkSet);
+	conf.set('foo', '🐴');
+	unsubscribe();
+	conf.set('foo', fixture);
+});
+
 // See #32
 test('doesn\'t write to disk upon instanciation if and only if the store didn\'t change', t => {
 	let exists = fs.existsSync(t.context.conf.path);


### PR DESCRIPTION
Fix #45: Hi this is my first contribution so I just attempted to follow the existing convention.
Please let me know if there are any corner cases I didn't consider. I ran tests with node `v6.16.0`, `v8.14.0`, `v10.15.0`.

I moved `isEqual` to a static method and reused it in both `onDidChange` and `onDidAnyChange`.