### PR TITLE
Add `serialize` and `deserialize` options

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ module.exports = class Conf {
 			configName: 'config',
 			fileExtension: 'json',
 			projectSuffix: 'nodejs',
+			serialize: value => JSON.stringify(value, null, '\t'),
+			deserialize: JSON.parse,
 			...options
 		};
 
@@ -59,6 +61,8 @@ module.exports = class Conf {
 
 		this.events = new EventEmitter();
 		this.encryptionKey = options.encryptionKey;
+		this.serialize = options.serialize;
+		this.deserialize = options.deserialize;
 
 		const fileExtension = options.fileExtension ? `.${options.fileExtension}` : '';
 		this.path = path.resolve(options.cwd, `${options.configName}${fileExtension}`);
@@ -161,7 +165,7 @@ module.exports = class Conf {
 				} catch (_) {}
 			}
 
-			return Object.assign(plainObject(), JSON.parse(data));
+			return Object.assign(plainObject(), this.deserialize(data));
 		} catch (error) {
 			if (error.code === 'ENOENT') {
 				// TODO: Use `fs.mkdirSync` `recursive` option when targeting Node.js 12
@@ -181,7 +185,7 @@ module.exports = class Conf {
 		// Ensure the directory exists as it could have been deleted in the meantime
 		makeDir.sync(path.dirname(this.path));
 
-		let data = JSON.stringify(value, null, '\t');
+		let data = this.serialize(value);
 
 		if (this.encryptionKey) {
 			const cipher = crypto.createCipher('aes-256-cbc', this.encryptionKey);

--- a/readme.md
+++ b/readme.md
@@ -210,12 +210,14 @@ Example using YAML:
 
 ```js
 const yaml = require('js-yaml');
+
 const config = new Conf({
 	fileExtension: 'yaml',
 	serialize: yaml.safeDump,
 	deserialize: yaml.safeLoad
 });
 ```
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,24 @@ Extension of the config file.
 
 You would usually not need this, but could be useful if you want to interact with a file with a custom file extension that can be associated with your app. These might be simple save/export/preference files that are intended to be shareable or saved outside of the app.
 
+#### serialize
+
+type: `Function`<br>
+Default: `value => JSON.stringify(value, null '\t')`
+
+Function to serialize the config object to utf8 string when writing to the config file.
+
+You would usually not need this, but could be useful if you want to use a format other than JSON.
+
+#### deserialize
+
+type: `Function`<br>
+Default: `JSON.parse`
+
+Function to deserialize the config object from utf8 when reading the config file.
+
+You would usually not need this, but could be useful if you want to use a format other than JSON.
+
 #### projectSuffix
 
 Type: `string`<br>
@@ -184,6 +202,20 @@ Get the path to the config file.
 
 I'm also the author of `configstore`. While it's pretty good, I did make some mistakes early on that are hard to change at this point. This module is the result of everything I learned from making `configstore`. Mainly where the config is stored. In `configstore`, the config is stored in `~/.config` (which is mainly a Linux convention) on all systems, while `conf` stores config in the system default [user config directory](https://github.com/sindresorhus/env-paths#pathsconfig). The `~/.config` directory, it turns out, often have an incorrect permission on macOS and Windows, which has caused a lot of grief for users.
 
+### Can I use YAML or another serialization format?
+
+The `serialize` and `deserialize` options can be used to customize the format of the config file, as long as the representation is compatible with `utf8` encoding.
+
+Example using YAML:
+
+```js
+const yaml = require('js-yaml');
+const config = new Conf({
+	fileExtension: 'yaml',
+	serialize: yaml.safeDump,
+	deserialize: yaml.safeLoad
+});
+```
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -109,21 +109,21 @@ You would usually not need this, but could be useful if you want to interact wit
 
 #### serialize
 
-type: `Function`<br>
-Default: `value => JSON.stringify(value, null '\t')`
+Type: `Function`<br>
+Default: `value => JSON.stringify(value, null, '\t')`
 
-Function to serialize the config object to utf8 string when writing to the config file.
+Function to serialize the config object to a UTF-8 string when writing the config file.
 
-You would usually not need this, but could be useful if you want to use a format other than JSON.
+You would usually not need this, but it could be useful if you want to use a format other than JSON.
 
 #### deserialize
 
 type: `Function`<br>
 Default: `JSON.parse`
 
-Function to deserialize the config object from utf8 when reading the config file.
+Function to deserialize the config object from a UTF-8 string when reading the config file.
 
-You would usually not need this, but could be useful if you want to use a format other than JSON.
+You would usually not need this, but it could be useful if you want to use a format other than JSON.
 
 #### projectSuffix
 

--- a/test.js
+++ b/test.js
@@ -204,6 +204,30 @@ test('`fileExtension` option = empty string', t => {
 	t.is(path.basename(conf.path), configName);
 });
 
+test('`serialize` and `deserialize` options', t => {
+	t.plan(4);
+	const serialized = `foo:${fixture}`;
+	const deserialized = {foo: fixture};
+	const serialize = value => {
+		t.is(value, deserialized);
+		return serialized;
+	};
+
+	const deserialize = value => {
+		t.is(value, serialized);
+		return deserialized;
+	};
+
+	const conf = new Conf({
+		cwd: tempy.directory(),
+		serialize,
+		deserialize
+	});
+	t.deepEqual(conf.store, {});
+	conf.store = deserialized;
+	t.deepEqual(conf.store, deserialized);
+});
+
 test('`projectName` option', t => {
 	const projectName = 'conf-fixture-project-name';
 	const conf = new Conf({projectName});


### PR DESCRIPTION
@sindresorhus I decided to move the PR from yeoman/configstore#60 to here per your suggestion.

I think I incorporated all of your feedback from that PR except I didn't do anything special if the user passes `JSON.stringify` for `serialize`, though because I think it would be surprising to the user for the method they passed to not actually be used. Why would someone override the default with the intent of preserving the default?