### PR TITLE
Fix path derivation logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,19 +33,6 @@ const checkValueType = (key, value) => {
 
 class Conf {
 	constructor(options) {
-		const pkgPath = pkgUp.sync(parentDir);
-
-		options = {
-			// Can't use `require` because of Webpack being annoying:
-			// https://github.com/webpack/webpack/issues/196
-			projectName: pkgPath && JSON.parse(fs.readFileSync(pkgPath, 'utf8')).name,
-			...options
-		};
-
-		if (!options.projectName && !options.cwd) {
-			throw new Error('Project name could not be inferred. Please specify the `projectName` option.');
-		}
-
 		options = {
 			configName: 'config',
 			fileExtension: 'json',
@@ -57,6 +44,17 @@ class Conf {
 		};
 
 		if (!options.cwd) {
+			if (!options.projectName) {
+				const pkgPath = pkgUp.sync(parentDir);
+				// Can't use `require` because of Webpack being annoying:
+				// https://github.com/webpack/webpack/issues/196
+				options.projectName = pkgPath && JSON.parse(fs.readFileSync(pkgPath, 'utf8')).name;
+			}
+
+			if (!options.projectName) {
+				throw new Error('Project name could not be inferred. Please specify the `projectName` option.');
+			}
+
 			options.cwd = envPaths(options.projectName, {suffix: options.projectSuffix}).config;
 		}
 


### PR DESCRIPTION
Current logic to derive the storage path unnecessarily attempts to locate and access a `package.json` file when you provide `projectName` or `cwd` as override options to the constructor. This PR fixes that bug.

**Expected:**: Creating a conf object with options `projectName` or `cwd` defined shouldn't cause the module to locate and access `package.json` file.
**Actual:** Creating a conf object with options `projectName` or `cwd` defined does cause the module to locate and access `package.json` file.

The bug is causing Mac App Store version of the Bitwarden application to hang on launch when there exists a `package.json` file in the user's home folder. See this PR for more information: https://github.com/sindresorhus/electron-store/issues/59