### PR TITLE
Replace deprecated crypto methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,10 @@ class Conf {
 
 			if (this.encryptionKey) {
 				try {
-					const decipher = crypto.createDecipher(encryptionAlgorithm, this.encryptionKey);
+					const iv = Buffer.alloc(16);
+					const key = crypto.pbkdf2Sync(this.encryptionKey, iv.toString(), 10000, 32, 'sha512');
+
+					const decipher = crypto.createDecipheriv(encryptionAlgorithm, key, iv);
 					data = Buffer.concat([decipher.update(data), decipher.final()]);
 				} catch (_) {}
 			}
@@ -242,7 +245,10 @@ class Conf {
 		let data = this.serialize(value);
 
 		if (this.encryptionKey) {
-			const cipher = crypto.createCipher(encryptionAlgorithm, this.encryptionKey);
+			const iv = Buffer.alloc(16);
+			const key = crypto.pbkdf2Sync(this.encryptionKey, iv.toString(), 10000, 32, 'sha512');
+
+			const cipher = crypto.createCipheriv(encryptionAlgorithm, key, iv);
 			data = Buffer.concat([cipher.update(Buffer.from(data)), cipher.final()]);
 		}
 


### PR DESCRIPTION
I wanted to fix https://github.com/sindresorhus/electron-store/issues/67, but the fix had to be done here.

Since the README states :

> Note that this is not intended for security purposes, since the encryption key would be easily found inside a plain-text Node.js app.

I permitted myself to use a non-random IV.

<details>
<summary>Test results</summary>
Node 11.15.0 

![Test results on Node 11.15.0](https://user-images.githubusercontent.com/6715182/58264098-cbc2ec00-7d6c-11e9-8d0f-283834b78e6a.png)

Node 10.15.3 

![Test results on Node 10.15.3 ](https://user-images.githubusercontent.com/6715182/58264194-fb71f400-7d6c-11e9-983f-10dc105ee6e5.png)

Node 8.16.0

![Test results on Node 8.16.0](https://user-images.githubusercontent.com/6715182/58264327-3116dd00-7d6d-11e9-938f-074d54634760.png)
</details>

Also I would be very grateful if you could indicate me the next step so I can help you resolve https://github.com/sindresorhus/electron-store/issues/67

Thanks in advance !
