### PR TITLE
Add support for setting/getting Date objects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -233,7 +233,6 @@ declare namespace Conf {
 		readonly watch?: boolean;
 
 		/**
-		Conf can automatically (de)serialize some objects/types.
 		As stated before `.set()` only accepts JSON serializable values, so you can't use `undefined`, `function` or `symbol`.
 		Additionally Conf has the ability to automatically serialize and deserialize pre-configured objects.
 		Currently supported objects are:
@@ -241,22 +240,22 @@ declare namespace Conf {
 		Extra types can be added to a Conf instance via passing the `extraTypes` option to the constructor.
 		Each element of the array defines an extra type, that is going to be automatically serialized when stored and deserialized when retrieved.
 
-		@example
+		@example ````The following example demonstrates the configuration of the `RegExp` type.
 		```
 		const Conf = new require('conf');
 
-		const extraTypeDate = {
-			name: 'Date',
-			isInstance: object => object instanceof Date,
-			convertFrom: value => value.getTime(),
-			convertTo: value = new Date(value)
+		const extraTypeRegExp = {
+			name: 'regex',
+			isInstance: object => object instanceof RegExp,
+			convertFrom: value => {pattern: value.source, flags: value.flags},
+			convertTo: value => new RegExp(value.pattern, value.flags)
 		};
-		const config = new Conf({extraTypes: [extraTypeDate]});
+		const config = new Conf({extraTypes: [extraTypeRegExp]});
 
-		config.set('myDate', new Date());
-		const myDate = config.get('myDate');
-		console.log(myDate.toDateString());
-		//=> Tue Apr 07 2020
+		config.set('myRegex', new RegExp('as.*', 'gi'));
+		const myRegex = config.get('myRegex');
+		console.log(myRegex.exec('asdfgh'));
+		//=> ['asdfgh']
 		```
 		*/
 		readonly extraTypes?: Conf.ExtraType<unknown>[];
@@ -272,14 +271,20 @@ declare namespace Conf {
 		name: string,
 		/**
 		Determines whether an object is of the defined type.
+
+		@returns True if the object is of the defined type, otherwise false.
 		*/
 		isInstance: (value: T) => boolean,
 		/**
 		Takes the object of the defined type and deserializes it.
+
+		@returns A JSON serializable representation of the custom type.
 		*/
 		convertFrom: (value: T) => JsonValue,
 		/**
 		Takes the serialized value and deserializes it.
+
+		@returns The type that is defined.
 		*/
 		convertTo: (value: JsonValue) => T
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -238,13 +238,6 @@ declare namespace Conf {
 		readonly watch?: boolean;
 	}
 
-	interface ExtraType<T> {
-		name: string,
-		instance: T,
-		convertFrom: (val: T) => string | number,
-		convertTo: (val: string) => T
-	}
-
 	/**
 	 * Defines a type, that's (de)serialization is automatically handled
 	 */
@@ -264,7 +257,7 @@ declare namespace Conf {
 		/**
 		 * Convert the stored JsonValue to this type
 		 */
-		convertTo: (value: string) => T
+		convertTo: (value: JsonValue) => T
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -216,6 +216,13 @@ declare namespace Conf {
 		*/
 		readonly watch?: boolean;
 	}
+
+	interface ExtraType<T> {
+		name: string,
+		instance: T,
+		convertFrom: (val: T) => string | number,
+		convertTo: (val: string) => T
+	}
 }
 
 /**
@@ -225,6 +232,7 @@ declare class Conf<T = any> implements Iterable<[keyof T, T[keyof T]]> {
 	store: T;
 	readonly path: string;
 	readonly size: number;
+	readonly extraTypes: Conf.ExtraType<any>[];
 
 	/**
 	Changes are written to disk atomically, so if the process crashes during a write, it will not corrupt the existing config.

--- a/index.d.ts
+++ b/index.d.ts
@@ -231,6 +231,35 @@ declare namespace Conf {
 		@default false
 		*/
 		readonly watch?: boolean;
+
+		/**
+		Conf can automatically (de)serialize some objects/types.
+		As stated before `.set()` only accepts JSON serializable values, so you can't use `undefined`, `function` or `symbol`.
+		Additionally Conf has the ability to automatically serialize and deserialize pre-configured objects.
+		Currently supported objects are:
+		- `Date` - serializes the Date to milliseconds, then back to a `Date` object when the getter is called
+		Extra types can be added to a Conf instance via passing the `extraTypes` option to the constructor.
+		Each element of the array defines an extra type, that is going to be automatically serialized when stored and deserialized when retrieved.
+
+		@example
+		```
+		const Conf = new require('conf');
+
+		const extraTypeDate = {
+			name: 'Date',
+			isInstance: object => object instanceof Date,
+			convertFrom: value => value.getTime(),
+			convertTo: value = new Date(value)
+		};
+		const config = new Conf({extraTypes: [extraTypeDate]});
+
+		config.set('myDate', new Date());
+		const myDate = config.get('myDate');
+		console.log(myDate.toDateString());
+		//=> Tue Apr 07 2020
+		```
+		*/
+		readonly extraTypes?: Conf.ExtraType<unknown>[];
 	}
 
 	/**
@@ -263,36 +292,7 @@ declare class Conf<T = any> implements Iterable<[keyof T, T[keyof T]]> {
 	store: T;
 	readonly path: string;
 	readonly size: number;
-	/**
-	Conf can automatically (de)serialize some objects/types.
-	As stated before `.set()` only accepts JSON serializable values, so you can't use `undefined`, `function` or `symbol`.
-	Additionally Conf has the ability to automatically serialize and deserialize pre-configured objects.
-	Currently supported objects are:
-	- `Date` - serializes the Date to milliseconds, then back to a `Date` object when the getter is called
-	Extra types can be added to a Conf instance via the `extraTypes` array.
-	Each element of the array defines an extra type, that is going to be automatically serialized when stored and deserialized when retrieved.
-	Once you've created an extra type object you can `push` it to the extraTypes array.
-
-	@example
-	```
-		const Conf = new require('conf');
-
-		const config = new Conf();
-		const extraTypeDate = {
-			name: 'Date',
-			isInstance: object => object instanceof Date,
-			convertFrom: value => value.getTime(),
-			convertTo: value = new Date(value)
-		};
-
-		config.extraTypes.push(extraTypeDate);
-		config.set('myDate', new Date());
-		const myDate = config.get('myDate');
-		console.log(myDate.toDateString());
-		//=> Tue Apr 07 2020
-	```
-	*/
-	extraTypes: Conf.ExtraType<unknown>[];
+	readonly extraTypes: Conf.ExtraType<unknown>[];
 
 	/**
 	Changes are written to disk atomically, so if the process crashes during a write, it will not corrupt the existing config.

--- a/index.d.ts
+++ b/index.d.ts
@@ -270,7 +270,7 @@ declare class Conf<T = any> implements Iterable<[keyof T, T[keyof T]]> {
 	Set an item.
 
 	@param key - You can use [dot-notation](https://github.com/sindresorhus/dot-prop) in a key to access nested properties.
-	@param value - Must be JSON serializable. Trying to set the type `undefined`, `function`, or `symbol` will result in a `TypeError`.
+	@param value - Must be JSON serializable. Trying to set the type `undefined`, `function`, or `symbol` will result in a `TypeError`. Additionally Conf automatically seralizes and deserializes `Date` objects
 	*/
 	set<K extends keyof T>(key: K, value: T[K]): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -223,6 +223,13 @@ declare namespace Conf {
 		convertFrom: (val: T) => string | number,
 		convertTo: (val: string) => T
 	}
+
+	interface ExtraType<T> {
+		name: string,
+		instance: T,
+		convertFrom: (val: T) => string | number,
+		convertTo: (val: string) => T
+	}
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,23 +5,23 @@ declare namespace Conf {
 	type Schema = JSONSchema;
 
 	/**
-	 * Matches a JSON object
-	 */
+	Matches a JSON object.
+	*/
 	type JsonObject = { [key: string]: JsonValue };
 
 	/**
-	 * Matches any valid JSON value
-	 */
+	Matches any valid JSON value.
+	*/
 	type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
 
 	/**
-	 * A list of currently supported extra types
-	 */
+	A list of currently supported extra types.
+	*/
 	type SupportedExtraTypes = Date;
 
 	/**
-	 * Matches a JSON array
-	 */
+	Matches a JSON array.
+	*/
 	interface JsonArray extends Array<JsonValue> { }
 
 
@@ -239,24 +239,24 @@ declare namespace Conf {
 	}
 
 	/**
-	 * Defines a type, that's (de)serialization is automatically handled
-	 */
+	Defines a type, that's (de)serialization is automatically handled.
+	*/
 	interface ExtraType<T> {
 		/**
-		 * The name of the type, this will be used to detect the type of the stored value
-		 */
+		The name of the type, this will be used to detect the type of the stored value.
+		*/
 		name: string,
 		/**
-		 * Check if the given value's type matches with the this type
-		 */
+		Check if the given value's type matches with the this type.
+		*/
 		isInstance: (value: T) => boolean,
 		/**
-		 * Convert a value with this type to JsonValue
-		 */
+		Convert a value with this type to JsonValue.
+		*/
 		convertFrom: (value: T) => JsonValue,
 		/**
-		 * Convert the stored JsonValue to this type
-		 */
+		Convert the stored JsonValue to this type.
+		*/
 		convertTo: (value: JsonValue) => T
 	}
 }
@@ -269,8 +269,14 @@ declare class Conf<T = any> implements Iterable<[keyof T, T[keyof T]]> {
 	readonly path: string;
 	readonly size: number;
 	/**
-	 * Conf can automatically (de)serialize some objects/types, for more information please visit [Supported Types](https://https://github.com/sindresorhus/conf#Supported-Types)
-	 */
+	Conf can automatically (de)serialize some objects/types.
+	As stated before `.set()` only accepts JSON serializable values, so you can't use `undefined`, `function` or `symbol`.
+	Additionally Conf has the ability to automatically serialize and deserialize pre-configured objects.
+	Currently supported objects are:
+	- `Date` - serializes the Date to milliseconds, then back to a `Date` object when the getter is called
+
+	If you want support for a new object/type please open a new issue for discussion.
+	*/
 	readonly extraTypes: Conf.ExtraType<Conf.SupportedExtraTypes>[];
 
 	/**

--- a/index.js
+++ b/index.js
@@ -552,9 +552,6 @@ class Conf {
 		value = this._serializeExtraTypes(value);
 
 		this._validate(value);
-		let data = this.serialize(value);
-
-		this._validate(value);
 		this._write(value);
 
 		this.events.emit('change');

--- a/index.js
+++ b/index.js
@@ -314,7 +314,6 @@ class Conf {
 		const stack = [];
 		const objectSeenList = [];
 
-		// AAstack.push(value);
 		stack.push({current: value, parent: null, key: null});
 		let circularReferenceCounter = 1;
 		while (stack.length > 0) {
@@ -325,15 +324,16 @@ class Conf {
 				// Current object is reference to an object already parsed
 				// current is the circular reference
 				// seenList.indexOf(current) is the object it's pointing to
+				const referenceTarget = objectSeenList[objectSeenList.indexOf(current)];
 				parent[key] = {
 					[TYPE_KEY]: 'circularObject',
-					value: parent[CIRCULAR_REF_KEY] || circularReferenceCounter
+					value: referenceTarget[CIRCULAR_REF_KEY] || circularReferenceCounter
 				};
-				if (parent[CIRCULAR_REF_KEY] === undefined) {
-					parent[CIRCULAR_REF_KEY] = circularReferenceCounter;
+				if (referenceTarget[CIRCULAR_REF_KEY] === undefined) {
+					referenceTarget[CIRCULAR_REF_KEY] = circularReferenceCounter;
 					circularReferenceCounter++;
 				} else {
-					console.log(parent[CIRCULAR_REF_KEY]);
+					console.log(referenceTarget[CIRCULAR_REF_KEY]);
 				}
 
 				console.log('skipping pontentially circulation');
@@ -393,6 +393,7 @@ class Conf {
 
 			if (current[CIRCULAR_REF_KEY]) {
 				circularReferences[current[CIRCULAR_REF_KEY]] = current;
+				delete current[CIRCULAR_REF_KEY];
 			}
 
 			for (const [currentItemKey, currentItemValue] of Object.entries(current)) {

--- a/index.js
+++ b/index.js
@@ -530,6 +530,9 @@ class Conf {
 		value = this._serializeExtraTypes(value);
 
 		this._validate(value);
+		let data = this.serialize(value);
+
+		this._validate(value);
 		this._write(value);
 
 		this.events.emit('change');

--- a/index.js
+++ b/index.js
@@ -318,9 +318,7 @@ class Conf {
 		let circularReferenceCounter = 1;
 		while (stack.length > 0) {
 			const {current, parent, key} = stack.pop();
-			if (objectSeenList.indexOf(current) === -1) {
-				objectSeenList.push(current);
-			} else {
+			if (objectSeenList.includes(current)) {
 				// Current object is reference to an object already parsed
 				// current is the circular reference
 				// seenList.indexOf(current) is the object it's pointing to
@@ -329,15 +327,15 @@ class Conf {
 					[TYPE_KEY]: 'circularObject',
 					value: referenceTarget[CIRCULAR_REF_KEY] || circularReferenceCounter
 				};
+
 				if (referenceTarget[CIRCULAR_REF_KEY] === undefined) {
 					referenceTarget[CIRCULAR_REF_KEY] = circularReferenceCounter;
 					circularReferenceCounter++;
-				} else {
-					console.log(referenceTarget[CIRCULAR_REF_KEY]);
 				}
 
-				console.log('skipping pontentially circulation');
 				continue;
+			} else {
+				objectSeenList.push(current);
 			}
 
 			for (const [currentItemKey, currentItemValue] of Object.entries(current)) {
@@ -385,10 +383,10 @@ class Conf {
 		stack.push(value);
 		while (stack.length > 0) {
 			const current = stack.pop();
-			if (objectSeenList.indexOf(current) === -1) {
-				objectSeenList.push(current);
-			} else {
+			if (objectSeenList.includes(current)) {
 				continue;
+			} else {
+				objectSeenList.push(current);
 			}
 
 			if (current[CIRCULAR_REF_KEY]) {
@@ -399,7 +397,6 @@ class Conf {
 			for (const [currentItemKey, currentItemValue] of Object.entries(current)) {
 				if (currentItemValue[TYPE_KEY] !== undefined) {
 					if (currentItemValue[TYPE_KEY] === 'circularObject') {
-						console.log('Circular handing magic');
 						current[currentItemKey] = circularReferences[currentItemValue.value];
 					} else {
 						const currentType = this.extraTypes.find(typeInfo => typeInfo.name === currentItemValue[TYPE_KEY]);

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ class Conf {
 			serialize: value => JSON.stringify(value, null, '\t'),
 			deserialize: JSON.parse,
 			accessPropertiesByDotNotation: true,
+			extraTypes: [],
 			...options
 		};
 
@@ -60,7 +61,8 @@ class Conf {
 				isInstance: object => object instanceof Date,
 				convertFrom: value => value.getTime(),
 				convertTo: value => new Date(value)
-			}
+			},
+			...options.extraTypes
 		];
 
 		const getPackageData = onetime(() => {
@@ -312,9 +314,8 @@ class Conf {
 			return value;
 		}
 
-		for (const type of this.extraTypes) {
-			return type.convertTo(value);
-		}
+		const currentType = this.extraTypes.find(type => type.name === value[TYPE_KEY]);
+		return currentType.convertTo(value.value);
 	}
 
 	_serializeCircular(parent, key, referenceTarget, referenceCounter) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,13 +5,15 @@ type UnicornFoo = {
 	foo: string;
 	unicorn: boolean;
 	hello?: number;
+	myDate: Date;
 };
 
 const conf = new Conf<UnicornFoo>();
 new Conf<UnicornFoo>({
 	defaults: {
 		foo: 'bar',
-		unicorn: false
+		unicorn: false,
+		myDate: new Date(1990)
 	}
 });
 new Conf<UnicornFoo>({configName: ''});
@@ -39,6 +41,9 @@ new Conf<UnicornFoo>({
 		},
 		hello: {
 			type: 'number'
+		},
+		myDate: {
+			type: 'object'
 		}
 	}
 });
@@ -62,7 +67,9 @@ expectError(
 conf.set('hello', 1);
 conf.set('unicorn', false);
 conf.set({foo: 'nope'});
+conf.set('myDate', new Date());
 
+expectType<Date>(conf.get('myDate'));
 expectType<string>(conf.get('foo'));
 expectType<void>(conf.reset('foo', 'unicorn'));
 expectType<string>(conf.get('foo', 'bar'));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -26,7 +26,7 @@ new Conf<UnicornFoo>({encryptionKey: new DataView(new ArrayBuffer(2))});
 new Conf<UnicornFoo>({fileExtension: '.foo'});
 new Conf<UnicornFoo>({clearInvalidConfig: false});
 new Conf<UnicornFoo>({serialize: value => 'foo'});
-new Conf<UnicornFoo>({deserialize: string => ({foo: 'foo', unicorn: true})});
+new Conf<UnicornFoo>({deserialize: string => ({foo: 'foo', unicorn: true, myDate: new Date(1990)})});
 new Conf<UnicornFoo>({projectSuffix: 'foo'});
 new Conf<UnicornFoo>({watch: true});
 
@@ -86,7 +86,8 @@ off();
 
 conf.store = {
 	foo: 'bar',
-	unicorn: false
+	unicorn: false,
+	myDate: new Date(1991)
 };
 expectType<string>(conf.path);
 expectType<number>(conf.size);

--- a/readme.md
+++ b/readme.md
@@ -276,6 +276,8 @@ You can use [dot-notation](https://github.com/sindresorhus/dot-prop) in a `key` 
 
 The instance is [`iterable`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Iteration_protocols) so you can use it directly in a [`for…of`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Statements/for...of) loop.
 
+Please see the [Supported Types](#Supported-Types) section for more information about the (de)serialization of pre-configured objects.
+
 #### .set(key, value)
 
 Set an item.
@@ -355,6 +357,15 @@ conf.store = {
 #### .path
 
 Get the path to the config file.
+
+## Supported Types
+
+As stated before `.set()` only accepts JSON serializable values, so you can't use `undefined`, `function` or `symbol`.
+Additionally Conf has the ability to automatically serialize and deserialize pre-configured objects.
+Currently supported objects are:
+- `Date` - serializes the Date to milliseconds, then back to a `Date` object when the getter is called
+
+If you want support for a new object/type please open a new issue for discussion.
 
 ## FAQ
 

--- a/readme.md
+++ b/readme.md
@@ -410,23 +410,23 @@ Takes the serialized value and deserializes it.
 - It must return the type that is defined.
 
 #### Example
-The following example demonstrates the configuration of the `Date` type, that is internally supported by default.
+The following example demonstrates the configuration of the `RegExp` type.
 
 ```js
 const Conf = new require('conf');
 
-const extraTypeDate = {
-	name: 'Date',
-	isInstance: object => object instanceof Date,
-	convertFrom: value => value.getTime(),
-	convertTo: value = new Date(value)
+const extraTypeRegExp = {
+	name: 'regex',
+	isInstance: object => object instanceof RegExp,
+	convertFrom: value => {pattern: value.source, flags: value.flags},
+	convertTo: value => new RegExp(value.pattern, value.flags)
 };
-const config = new Conf({extraTypes: [extraTypeDate]});
+const config = new Conf({extraTypes: [extraTypeRegExp]});
 
-config.set('myDate', new Date());
-const myDate = config.get('myDate');
-console.log(myDate.toDateString());
-//=> Tue Apr 07 2020
+config.set('myRegex', new RegExp('as.*', 'gi'));
+const myRegex = config.get('myRegex');
+console.log(myRegex.exec('asdfgh'));
+//=> ['asdfgh']
 ```
 
 ## FAQ

--- a/readme.md
+++ b/readme.md
@@ -365,7 +365,70 @@ Additionally Conf has the ability to automatically serialize and deserialize pre
 Currently supported objects are:
 - `Date` - serializes the Date to milliseconds, then back to a `Date` object when the getter is called
 
-If you want support for a new object/type please open a new issue for discussion.
+### Configure types for serialization
+Extra types can be added to a Conf instance via the `extraTypes` array.
+Each element of the array defines an extra type that is going to be automatically serialized when stored and deserialized when retrieved.
+Once you've created an extra type object you need to `push` it to the extraTypes array.
+
+#### Extra type object
+
+Type: `object`
+
+Defines a type, that's (de)serialization is automatically handled.
+
+##### name
+
+Type: `string`
+
+The unique name describing the new type. This name identifies the custom type internally when (de)serializing the object.
+
+##### isInstance
+
+Type: `Function`
+
+Determines whether an object is of the defined type.
+
+- It has signature `isInstance(object)`, where object is of type `object`.
+- It must return a `boolean`, true if the object is of the defined type, otherwise false.
+
+##### convertFrom
+
+Type: `Function`
+
+Takes the object of the defined type and deserializes it.
+
+- It has signature `convertFrom(value)`, where value is of the type that is defined.
+- It must return a JSON serializable representation of the custom type.
+
+##### convertTo
+
+Type: `Function`
+
+Takes the serialized value and deserializes it.
+
+- It has signature `convertTo(value)`, where value is a JSON serializable type.
+- It must return the type that is defined.
+
+#### Example
+The following example demonstrates the configuration of the `Date` type, that is internally supported by default.
+
+```js
+const Conf = new require('conf');
+
+const config = new Conf();
+const extraTypeDate = {
+	name: 'Date',
+	isInstance: object => object instanceof Date,
+	convertFrom: value => value.getTime(),
+	convertTo: value = new Date(value)
+};
+
+config.extraTypes.push(extraTypeDate);
+config.set('myDate', new Date());
+const myDate = config.get('myDate');
+console.log(myDate.toDateString());
+//=> Tue Apr 07 2020
+```
 
 ## FAQ
 

--- a/readme.md
+++ b/readme.md
@@ -366,9 +366,9 @@ Currently supported objects are:
 - `Date` - serializes the Date to milliseconds, then back to a `Date` object when the getter is called
 
 ### Configure types for serialization
-Extra types can be added to a Conf instance via the `extraTypes` array.
-Each element of the array defines an extra type that is going to be automatically serialized when stored and deserialized when retrieved.
-Once you've created an extra type object you need to `push` it to the extraTypes array.
+
+Extra types can be added to a Conf instance via passing the `extraTypes` option to the constructor.
+Each element of the array defines an extra type, that is going to be automatically serialized when stored and deserialized when retrieved.
 
 #### Extra type object
 
@@ -415,15 +415,14 @@ The following example demonstrates the configuration of the `Date` type, that is
 ```js
 const Conf = new require('conf');
 
-const config = new Conf();
 const extraTypeDate = {
 	name: 'Date',
 	isInstance: object => object instanceof Date,
 	convertFrom: value => value.getTime(),
 	convertTo: value = new Date(value)
 };
+const config = new Conf({extraTypes: [extraTypeDate]});
 
-config.extraTypes.push(extraTypeDate);
 config.set('myDate', new Date());
 const myDate = config.get('myDate');
 console.log(myDate.toDateString());

--- a/test.js
+++ b/test.js
@@ -49,6 +49,12 @@ test('.set() - with object', t => {
 	t.is(t.context.config.get('baz.foo.bar'), 'baz');
 });
 
+test('.set() - with Date', t => {
+	t.context.config.set('dateobj', new Date());
+	const myDate = t.context.config.get('dateobj');
+	t.true(myDate instanceof Date);
+});
+
 test('.set() - with undefined', t => {
 	t.throws(() => {
 		t.context.config.set('foo', undefined);

--- a/test.js
+++ b/test.js
@@ -90,13 +90,33 @@ test('.set() - with Date in a nested array', t => {
 	t.true(myDateArray[3] instanceof Date);
 });
 
-test('.set()  - with circular objects', t => {
+test('.set()  - with Date and circular object', t => {
 	const circular = {myDate: new Date(), circulation: null};
 	circular.circulation = circular;
 	t.context.config.set('circular', circular);
 	const getCircular = t.context.config.get('circular');
 	t.true(getCircular.myDate instanceof Date);
 	t.true(getCircular.circulation.myDate instanceof Date);
+});
+
+test('.set() - with Date and 2 level deep circular object', t => {
+	const circular = {myDate: new Date(), circulationl1: {l2: null}};
+	circular.circulationl1.l2 = circular;
+	t.context.config.set('circular', circular);
+	const getCircular = t.context.config.get('circular');
+	t.true(getCircular.myDate instanceof Date);
+	t.true(getCircular.circulationl1.l2.myDate instanceof Date);
+});
+
+test('.set() - with Date and multiple circular objects', t => {
+	const circular = {myDate: new Date(), c1: null, c2: null};
+	circular.c1 = circular;
+	circular.c2 = circular;
+	t.context.config.set('circular', circular);
+	const getCircular = t.context.config.get('circular');
+	t.true(getCircular.myDate instanceof Date);
+	t.true(getCircular.c1.myDate instanceof Date);
+	t.true(getCircular.c2.myDate instanceof Date);
 });
 
 test('.set() - with undefined', t => {

--- a/test.js
+++ b/test.js
@@ -90,6 +90,15 @@ test('.set() - with Date in a nested array', t => {
 	t.true(myDateArray[3] instanceof Date);
 });
 
+test('.set()  - with circular objects', t => {
+	const circular = {myDate: new Date(), circulation: null};
+	circular.circulation = circular;
+	t.context.config.set('circular', circular);
+	const getCircular = t.context.config.get('circular');
+	t.true(getCircular.myDate instanceof Date);
+	t.true(getCircular.circulation.myDate instanceof Date);
+});
+
 test('.set() - with undefined', t => {
 	t.throws(() => {
 		t.context.config.set('foo', undefined);

--- a/test.js
+++ b/test.js
@@ -90,6 +90,19 @@ test('.set() - with Date in a nested array', t => {
 	t.true(myDateArray[3] instanceof Date);
 });
 
+test('.set()  - with normal types and circular object', t => {
+	const circular = {myString: 'this is a string', myInt: 5, myBoolean: true, circulation: null};
+	circular.circulation = circular;
+	t.context.config.set('circular', circular);
+	const getCircular = t.context.config.get('circular');
+	t.true(typeof getCircular.myString === 'string');
+	t.true(typeof getCircular.circulation.myString === 'string');
+	t.true(typeof getCircular.myInt === 'number');
+	t.true(typeof getCircular.circulation.myInt === 'number');
+	t.true(typeof getCircular.myBoolean === 'boolean');
+	t.true(typeof getCircular.circulation.myBoolean === 'boolean');
+});
+
 test('.set()  - with Date and circular object', t => {
 	const circular = {myDate: new Date(), circulation: null};
 	circular.circulation = circular;
@@ -99,6 +112,19 @@ test('.set()  - with Date and circular object', t => {
 	t.true(getCircular.circulation.myDate instanceof Date);
 });
 
+test('.set() - with normal types and 2 level deep circular object', t => {
+	const circular = {myString: 'this is a string', myInt: 5, myBoolean: true, circulationl1: {l2: null}};
+	circular.circulationl1.l2 = circular;
+	t.context.config.set('circular', circular);
+	const getCircular = t.context.config.get('circular');
+	t.true(typeof getCircular.myString === 'string');
+	t.true(typeof getCircular.circulationl1.l2.myString === 'string');
+	t.true(typeof getCircular.myInt === 'number');
+	t.true(typeof getCircular.circulationl1.l2.myInt === 'number');
+	t.true(typeof getCircular.myBoolean === 'boolean');
+	t.true(typeof getCircular.circulationl1.l2.myBoolean === 'boolean');
+});
+
 test('.set() - with Date and 2 level deep circular object', t => {
 	const circular = {myDate: new Date(), circulationl1: {l2: null}};
 	circular.circulationl1.l2 = circular;
@@ -106,6 +132,23 @@ test('.set() - with Date and 2 level deep circular object', t => {
 	const getCircular = t.context.config.get('circular');
 	t.true(getCircular.myDate instanceof Date);
 	t.true(getCircular.circulationl1.l2.myDate instanceof Date);
+});
+
+test('.set() - with normal types and multiple circular objects', t => {
+	const circular = {myString: 'this is a string', myInt: 5, myBoolean: true, c1: null, c2: null};
+	circular.c1 = circular;
+	circular.c2 = circular;
+	t.context.config.set('circular', circular);
+	const getCircular = t.context.config.get('circular');
+	t.true(typeof getCircular.myString === 'string');
+	t.true(typeof getCircular.c1.myString === 'string');
+	t.true(typeof getCircular.c2.myString === 'string');
+	t.true(typeof getCircular.myInt === 'number');
+	t.true(typeof getCircular.c1.myInt === 'number');
+	t.true(typeof getCircular.c2.myInt === 'number');
+	t.true(typeof getCircular.myBoolean === 'boolean');
+	t.true(typeof getCircular.c1.myBoolean === 'boolean');
+	t.true(typeof getCircular.c2.myBoolean === 'boolean');
 });
 
 test('.set() - with Date and multiple circular objects', t => {

--- a/test.js
+++ b/test.js
@@ -55,6 +55,12 @@ test('.set() - with Date', t => {
 	t.true(myDate instanceof Date);
 });
 
+test('.set() - with Date in a nested object', t => {
+	t.context.config.set('dateobj', {str: 'this is a string', date: new Date()});
+	const myDate = t.context.config.get('dateobj').date;
+	t.true(myDate instanceof Date);
+});
+
 test('.set() - with undefined', t => {
 	t.throws(() => {
 		t.context.config.set('foo', undefined);

--- a/test.js
+++ b/test.js
@@ -61,6 +61,35 @@ test('.set() - with Date in a nested object', t => {
 	t.true(myDate instanceof Date);
 });
 
+test('.set() - with Date in a array', t => {
+	t.context.config.set('datearray', [new Date(), 'asd', 1337, new Date()]);
+	const myDateArray = t.context.config.get('datearray');
+	t.true(myDateArray[0] instanceof Date);
+	t.true(myDateArray[3] instanceof Date);
+});
+
+test('.set() - with Date in a object inside array', t => {
+	t.context.config.set('datearray', [{date: new Date(), dummy: 'dummy', num: -1337}, 'asd', 1337, new Date()]);
+	const myDateArray = t.context.config.get('datearray');
+	t.true(myDateArray[0].date instanceof Date);
+	t.true(myDateArray[3] instanceof Date);
+});
+
+test('.set() - with Date in a nested object inside array', t => {
+	t.context.config.set('datearray', [{nested: {date: new Date(), nestedDummy: 'nested dummy'}, dummy: 'dummy', num: -1337}, 'asd', 1337, new Date()]);
+	const myDateArray = t.context.config.get('datearray');
+	t.true(myDateArray[0].nested.date instanceof Date);
+	t.true(myDateArray[3] instanceof Date);
+});
+
+test('.set() - with Date in a nested array', t => {
+	t.context.config.set('datearray', [[1, 2, 3], 'asd', [new Date(), 1337, new Date()], new Date()]);
+	const myDateArray = t.context.config.get('datearray');
+	t.true(myDateArray[2][0] instanceof Date);
+	t.true(myDateArray[2][2] instanceof Date);
+	t.true(myDateArray[3] instanceof Date);
+});
+
 test('.set() - with undefined', t => {
 	t.throws(() => {
 		t.context.config.set('foo', undefined);


### PR DESCRIPTION
Implementing a new feature described in issue https://github.com/sindresorhus/electron-store/issues/18.  
Type information is stored under `${INTERNAL_KEY}.type` as suggested, the `get` method checks if there's a type key present, if there's it converts the value to the type before returning it.  
The `set` methods checks if the value passed in is an `instance of Date`, if it is it stores it as an object like:
```js
key: {
    __internal__.type: 'Date',
    val: valuePassedIn
}
````
I've also added a test to `test.js` to test for the setting and getting Date objects
Let me know if there's anything I could change. For example I chose to include type information only for Date objects, but it might be better to store type information for every key-value pair to be more consistent, but it would also make the object and the file larger.