### PR TITLE
New option suggestion: direct assignment of ajv validate function

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,12 @@ class Conf {
 					this._defaultValues[key] = value.default;
 				}
 			}
+		} else if (options.ajvValidator) {
+			if (typeof options.ajvValidator !== 'function') {
+				throw new TypeError('The `schema` option must be an object.');
+			}
+
+			this._validator = options.ajvValidator;
 		}
 
 		if (options.defaults) {

--- a/test.js
+++ b/test.js
@@ -696,6 +696,36 @@ test('schema - validate Conf default', t => {
 	}, 'Config schema violation: `foo` should be string');
 });
 
+test('ajvValidator - validate Conf default', t => {
+	const Ajv = require('ajv');
+	const ajv = new Ajv({
+		allErrors: true,
+		format: 'full',
+		useDefaults: true,
+		errorDataPath: 'property'
+	});
+	const schema = {
+		type: 'object',
+		properties: {
+			foo: {
+				type: 'string'
+			}
+		}
+	};
+
+	const validator = ajv.compile(schema);
+
+	t.throws(() => {
+		new Conf({ // eslint-disable-line no-new
+			cwd: tempy.directory(),
+			defaults: {
+				foo: 1
+			},
+			ajvValidator: validator
+		});
+	}, 'Config schema violation: `foo` should be string');
+});
+
 test('.get() - without dot notation', t => {
 	t.is(t.context.configWithoutDotNotation.get('foo'), undefined);
 	t.is(t.context.configWithoutDotNotation.get('foo', '🐴'), '🐴');


### PR DESCRIPTION
While the current support for JSON scheme validation is great, it limits more advanced usage of ajv. To fully unleash ajv capability, I'd love for conf to support an option to let user provide the ready-to-go ajv validator function rather than using the internally generated one via `schema` option. This PR implements such option, which I tentatively named `ajvValidator`.

Additional Notes on PR:
- `schema` option take precedence over `ajvValidator` option
- `ajvValidator` option is checked to be sure it's a function
- As far as I can tell, I don't think this PR affects the operation of `_validate()` unless user specifies a non-ajv validation function.
- I've added a test for the new option in `test.js` based on the existing `schema` option test

