### PR TITLE
Fix issue with package.json inference when using the `cwd` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class Conf {
 		};
 
 		const getPackageData = onetime(() => {
-			const packagePath = pkgUp.sync(parentDir);
+			const packagePath = pkgUp.sync({cwd: parentDir});
 			// Can't use `require` because of Webpack being annoying:
 			// https://github.com/webpack/webpack/issues/196
 			const packageData = packagePath && JSON.parse(fs.readFileSync(packagePath, 'utf8'));


### PR DESCRIPTION
Ever since version 3 pkg-up accepts the `cwd` argument as an object (instead of a plain string).

https://github.com/sindresorhus/pkg-up/commit/7b8d9cfc5d9f7bb47cb3e38359a0cfa0e92caedd#diff-168726dbe96b3ce427e7fedce31bb0bc