### PR TITLE
Fix _shouldPerformMigration condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,7 +266,7 @@ class Conf {
 
 	_shouldPerformMigration(candidateVersion, previousMigratedVersion, versionToMigrate) {
 		if (this._isVersionInRangeFormat(candidateVersion)) {
-			if (previousMigratedVersion !== '0.0.0' && semver.satisfies(previousMigratedVersion, candidateVersion)) {
+			if (previousMigratedVersion !== '0.0.0' && !semver.satisfies(previousMigratedVersion, candidateVersion)) {
 				return false;
 			}
 


### PR DESCRIPTION
Hi I'm using electron-store library but I found the bug in migrations 

Migration works when I make a new store file, but it fails when I open a store file of a previous version.

It means that `__internal__/migrations/versions` is updated but the store data is not.
While I was debugging, I found that the `_shouldPerformMigration` function returns `false` even though semver range is `true`, because of [line269](https://github.com/sindresorhus/conf/blob/v6.2.4/index.js#L269) in index.js

I think the condition for semver range should be false here. Am I right?
Making the suggested change fixed the problem for my case.

