### PR TITLE
Adding schema as a variable will not work

### DIFF
--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -55,6 +55,30 @@ new Conf<UnicornFoo>({
 	}
 });
 
+const schema = {
+	foo: {
+		type: 'string',
+		default: 'foobar'
+	},
+	unicorn: {
+		type: 'boolean'
+	},
+	hello: {
+		type: 'number'
+	},
+	nested: {
+		type: 'object',
+		properties: {
+			prop: {
+				type: 'number'
+			}
+		}
+	}
+}
+new Conf<UnicornFoo>({
+	schema
+});
+
 conf.set('hello', 1);
 conf.set('unicorn', false);
 conf.set({foo: 'nope'});


### PR DESCRIPTION
It will complain if you add it like this, but not if you define it inside.

I have no idea why, I don't know enough about typescript to know the difference.