### PR TITLE
fix(#120): allow for passing schema without explicit typing

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -46,7 +46,7 @@ export interface Options<T> {
 
 	**Note:** The `default` value will be overwritten by the `defaults` option if set.
 	*/
-	schema?: Schema<T>;
+	schema?: Schema<T> | object;
 
 	/**
 	Name of the config file (without extension).

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-new */
 import {expectType, expectAssignable} from 'tsd';
-import Conf from '../source';
+import Conf, { Schema } from '../source';
 
 type UnicornFoo = {
 	foo: string;
@@ -53,6 +53,56 @@ new Conf<UnicornFoo>({
 			}
 		}
 	}
+});
+
+const schemaWithType: Schema<UnicornFoo> = {
+	foo: {
+		type: 'string',
+		default: 'foobar'
+	},
+	unicorn: {
+		type: 'boolean'
+	},
+	hello: {
+		type: 'number'
+	},
+	nested: {
+		type: 'object',
+		properties: {
+			prop: {
+				type: 'number'
+			}
+		}
+	}
+}
+
+new Conf<UnicornFoo>({
+	schema:schemaWithType,
+});
+
+const schema = {
+	foo: {
+		type: 'string',
+		default: 'foobar'
+	},
+	unicorn: {
+		type: 'boolean'
+	},
+	hello: {
+		type: 'number'
+	},
+	nested: {
+		type: 'object',
+		properties: {
+			prop: {
+				type: 'number'
+			}
+		}
+	}
+}
+
+new Conf<UnicornFoo>({
+	schema
 });
 
 conf.set('hello', 1);


### PR DESCRIPTION
Added an object type to the schema to support implicit typing for the schema. Fixes #120 .