### PR TITLE
Add `.appendToArray()` method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -280,7 +280,7 @@ The instance is [`iterable`](https://developer.mozilla.org/en/docs/Web/JavaScrip
 
 Set an item.
 
-The `value` must be JSON serializable. Trying to set the type `undefined`, `function`, or `symbol` will result in a TypeError.
+The `value` must be JSON serializable. Trying to set the type like `undefined`, `function`, or `symbol` will result in a `TypeError`.
 
 #### .set(object)
 
@@ -340,14 +340,14 @@ unsubscribe();
 
 #### .appendToArray(key, value)
 
-Append an item to array.
+Append `value` to an array item. If the item (`key`) doesn't exist, a new array with the `value` will be created. If item exists and is not an array, it will result in a `TypeError`.
 
-The `value` must be JSON serializable. Trying to set the type `undefined`, `function`, or `symbol` will result in a TypeError.
+The `value` must be JSON serializable. Trying to set the type like `undefined`, `function`, or `symbol` will result in a `TypeError`.
 
 ```js
-config.appendToArray('foo.unicorns', '🦄')
-config.appendToArray('foo.unicorns', '🦄')
-console.log(config.get('foo.unicorns'))
+config.appendToArray('foo.unicorns', '🦄');
+config.appendToArray('foo.unicorns', '🦄');
+console.log(config.get('foo.unicorns'));
 //=> ['🦄', '🦄']
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -338,6 +338,19 @@ const unsubscribe = conf.onDidAnyChange(key, callback);
 unsubscribe();
 ```
 
+#### .appendToArray(key, value)
+
+Append an item to array.
+
+The `value` must be JSON serializable. Trying to set the type `undefined`, `function`, or `symbol` will result in a TypeError.
+
+```js
+config.appendToArray('foo.unicorns', '🦄')
+config.appendToArray('foo.unicorns', '🦄')
+console.log(config.get('foo.unicorns'))
+//=> ['🦄', '🦄']
+```
+
 #### .size
 
 Get the item count.

--- a/source/index.ts
+++ b/source/index.ts
@@ -166,7 +166,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 	@param defaultValue - The default value if the item does not exist.
 	*/
 	get<Key extends keyof T>(key: Key): T[Key];
-	get<Key extends keyof T>(key: Key, defaultValue: Required<T>[Key]): Required<T>[Key];
+	get<Key extends keyof T>(key: Key, defaultValue: Required<T>[Key] | Required<unknown>): Required<T>[Key];
 	// This overload is used for dot-notation access.
 	// We exclude `keyof T` as an incorrect type for the default value should not fall through to this overload.
 	get<Key extends string, Value = unknown>(key: Exclude<Key, keyof T>, defaultValue?: Value): Value;
@@ -224,21 +224,22 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 	}
 
 	/**
-  Append an item to array
+	Append an item to array
 
 	@param {key|object} - You can use [dot-notation](https://github.com/sindresorhus/dot-prop) in a key to access nested properties. Or a hashmap of items to set at once.
 	@param value - Must be JSON serializable. Trying to set the type `undefined`, `function`, or `symbol` will result in a `TypeError`.
   */
-	appendToArray<Key extends keyof T>(key: Key, value: Required<T>[Key]): void;
+	appendToArray<Key extends keyof T, Value = T[Key][0]>(key: Key, value: Value): void;
+	appendToArray(key: string, value: unknown): void;
 	// This overload is used for dot-notation access.
-	appendToArray<Key extends string>(key: Key, value: Required<T>[Key]): void {
-		const array: [] = this.get(key, [] as T[Key]);
+	appendToArray<Key extends string, Value = T[Key][0]>(key: Key, value: Value): void {
+		const array: [] = this.get(key, [] as Array<typeof value>);
 
 		if (!Array.isArray(array)) {
 			throw new TypeError(`The key \`${key}\` is already set to a non-array value`);
 		}
 
-		this.set(key, [...array, value]);
+		this.set(key, [...array, value] as T[Key]);
 	}
 
 	/**

--- a/source/index.ts
+++ b/source/index.ts
@@ -224,7 +224,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 	}
 
 	/**
-    Append an item or multiple items to an array
+    Append an item to array
 
 	@param {key|object} - You can use [dot-notation](https://github.com/sindresorhus/dot-prop) in a key to access nested properties. Or a hashmap of items to set at once.
 	@param value - Must be JSON serializable. Trying to set the type `undefined`, `function`, or `symbol` will result in a `TypeError`.

--- a/source/index.ts
+++ b/source/index.ts
@@ -224,22 +224,21 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 	}
 
 	/**
-    Append an item to array
+  Append an item to array
 
 	@param {key|object} - You can use [dot-notation](https://github.com/sindresorhus/dot-prop) in a key to access nested properties. Or a hashmap of items to set at once.
 	@param value - Must be JSON serializable. Trying to set the type `undefined`, `function`, or `symbol` will result in a `TypeError`.
-    */
+  */
 	appendToArray<Key extends keyof T>(key: Key, value: Required<T>[Key]): void;
 	// This overload is used for dot-notation access.
 	appendToArray<Key extends string>(key: Key, value: Required<T>[Key]): void {
-		const list = this.get(key, [] as T[Key]);
+		const array: [] = this.get(key, [] as T[Key]);
 
-		if (!Array.isArray(list)) {
-			throw new TypeError('Config param already set and is not array');
+		if (!Array.isArray(array)) {
+			throw new TypeError(`The key \`${key}\` is already set to a non-array value`);
 		}
 
-		list.push(value);
-		this.set(key, list);
+		this.set(key, [...array, value]);
 	}
 
 	/**

--- a/source/index.ts
+++ b/source/index.ts
@@ -224,6 +224,25 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 	}
 
 	/**
+    Append an item or multiple items to an array
+
+	@param {key|object} - You can use [dot-notation](https://github.com/sindresorhus/dot-prop) in a key to access nested properties. Or a hashmap of items to set at once.
+	@param value - Must be JSON serializable. Trying to set the type `undefined`, `function`, or `symbol` will result in a `TypeError`.
+    */
+	appendToArray<Key extends keyof T>(key: Key, value: Required<T>[Key]): void;
+	// This overload is used for dot-notation access.
+	appendToArray<Key extends string>(key: Key, value: Required<T>[Key]): void {
+		const list = this.get(key, [] as T[Key]);
+
+		if (!Array.isArray(list)) {
+			throw new TypeError('Config param already set and is not array');
+		}
+
+		list.push(value);
+		this.set(key, list);
+	}
+
+	/**
 	Check if an item exists.
 
 	@param key - The key of the item to check.

--- a/test/index.ts
+++ b/test/index.ts
@@ -110,6 +110,35 @@ test('.appendToArray()', t => {
 	t.deepEqual(t.context.config.get('bar'), ['🐴']);
 });
 
+test('.appendToArray() - array of objects', t => {
+	t.context.config.appendToArray('foo', {name: 'a'});
+	t.context.config.appendToArray('foo', {name: 'b'});
+	t.context.config.appendToArray('foo', {name: 'c'});
+	t.deepEqual(t.context.config.get('foo'), [
+		{name: 'a'},
+		{name: 'b'},
+		{name: 'c'}
+	]);
+});
+
+test('.appendToArray() - array of arrays', t => {
+	t.context.config.appendToArray('foo', [1]);
+	t.context.config.appendToArray('foo', [1, 2]);
+	t.context.config.appendToArray('foo', [{name: 'a'}]);
+	t.deepEqual(t.context.config.get('foo'), [
+		[1],
+		[1, 2],
+		[{name: 'a'}]
+	]);
+});
+
+test('.appendToArray() - value already set', t => {
+	t.context.config.set('foo', fixture);
+	t.throws(() => {
+		t.context.config.appendToArray('foo', fixture);
+	}, {message: 'The key `foo` is already set to a non-array value'});
+});
+
 test('.has()', t => {
 	t.context.config.set('foo', fixture);
 	t.context.config.set('baz.boo', fixture);

--- a/test/index.ts
+++ b/test/index.ts
@@ -99,6 +99,17 @@ test('.set() - invalid key', t => {
 	}, {message: 'Expected `key` to be of type `string` or `object`, got number'});
 });
 
+test('.appendToArray()', t => {
+	t.context.config.set('foo', [fixture]);
+	t.context.config.set('baz.boo', [fixture]);
+	t.context.config.appendToArray('foo', '🐴');
+	t.context.config.appendToArray('baz.boo', '🐴');
+	t.context.config.appendToArray('bar', '🐴'); // Will create new item with array
+	t.deepEqual(t.context.config.get('foo'), [fixture, '🐴']);
+	t.deepEqual(t.context.config.get('baz.boo'), [fixture, '🐴']);
+	t.deepEqual(t.context.config.get('bar'), ['🐴']);
+});
+
 test('.has()', t => {
 	t.context.config.set('foo', fixture);
 	t.context.config.set('baz.boo', fixture);


### PR DESCRIPTION
* Addresses https://github.com/sindresorhus/electron-store/issues/52
* Addresses #109

Allows appending or creating an array item with `.appendToArray` :

```
store.appendToArray('foo', 'a') // foo will be ['a']
store.appendToArray('foo', 'b') // foo will be ['a', 'b']
```