### PR TITLE
Fix readme typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -333,7 +333,7 @@ Watches the whole config object, calling `callback` on any changes.
 Returns a function which you can use to unsubscribe:
 
 ```js
-const unsubscribe = conf.onDidAnyChange(key, callback);
+const unsubscribe = conf.onDidAnyChange(callback);
 
 unsubscribe();
 ```


### PR DESCRIPTION
Fixes sindresorhus/electron-store#136, this fixes a typo in the example code for onDidAnyChange.