### PR TITLE
Provide way to omit __interal__ from store on get

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -40,8 +40,8 @@ const checkValueType = (key: string, value: unknown): void => {
 	}
 };
 
-const INTERNAL_KEY = '__internal__';
-const MIGRATION_KEY = `${INTERNAL_KEY}.migrations.version`;
+export const INTERNAL_KEY = '__internal__';
+export const MIGRATION_KEY = `${INTERNAL_KEY}.migrations.version`;
 
 class Conf<T extends Record<string, any> = Record<string, unknown>> implements Iterable<[keyof T, T[keyof T]]> {
 	readonly path: string;


### PR DESCRIPTION
The internal key causes some problems, both during write (https://github.com/sindresorhus/conf/issues/114) and at read (can't trust MyStore.keys() or MyStore.values() without omitting __internal__). We should at least export the variable so the client can manually omit it (and at best, provide a more ergonomic pattern—perhaps a WeakMap?)