### PR TITLE
Fix `.reset()` to correctly handle falsy default values

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -21,6 +21,10 @@ const createPlainObject = <T = unknown>(): T => {
 	return Object.create(null);
 };
 
+const isExist = <T = unknown>(data: T): boolean => {
+	return data !== undefined && data !== null
+}
+
 // Prevent caching of this module so module.parent is always accurate
 // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
 delete require.cache[__filename];
@@ -242,7 +246,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 	*/
 	reset<Key extends keyof T>(...keys: Key[]): void {
 		for (const key of keys) {
-			if (this.#defaultValues[key]) {
+			if (isExist(this.#defaultValues[key])) {
 				this.set(key, this.#defaultValues[key]);
 			}
 		}

--- a/source/index.ts
+++ b/source/index.ts
@@ -22,8 +22,8 @@ const createPlainObject = <T = unknown>(): T => {
 };
 
 const isExist = <T = unknown>(data: T): boolean => {
-	return data !== undefined && data !== null
-}
+	return data !== undefined && data !== null;
+};
 
 // Prevent caching of this module so module.parent is always accurate
 // eslint-disable-next-line @typescript-eslint/no-dynamic-delete

--- a/test/index.ts
+++ b/test/index.ts
@@ -127,13 +127,11 @@ test('.reset() - falsy `defaults` option', t => {
 	const defaultsValue: {
 		foo: number;
 		bar: string;
-		foz: undefined | string;
 		fox: boolean;
 		bax: boolean;
 	} = {
 		foo: 0,
 		bar: '',
-		foz: undefined,
 		fox: false,
 		bax: true
 	};
@@ -144,15 +142,13 @@ test('.reset() - falsy `defaults` option', t => {
 
 	store.set('foo', 5);
 	store.set('bar', 'exist');
-	store.set('foz', 'string');
 	store.set('fox', true);
 	store.set('fox', false);
 
-	store.reset('foo', 'bar', 'foz', 'fox', 'bax');
+	store.reset('foo', 'bar', 'fox', 'bax');
 
 	t.is(store.get('foo'), 0);
 	t.is(store.get('bar'), '');
-	t.is(store.get('foz'), undefined);
 	t.is(store.get('fox'), false);
 	t.is(store.get('bax'), true);
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -125,11 +125,11 @@ test('.reset() - `defaults` option', t => {
 
 test('.reset() - falsy `defaults` option', t => {
 	const defaultsValue: {
-		foo: number,
-		bar: string,
-		foz: undefined | string,
-		fox: boolean,
-		bax: boolean
+		foo: number;
+		bar: string;
+		foz: undefined | string;
+		fox: boolean;
+		bax: boolean;
 	} = {
 		foo: 0,
 		bar: '',

--- a/test/index.ts
+++ b/test/index.ts
@@ -123,7 +123,6 @@ test('.reset() - `defaults` option', t => {
 	t.is(store.get('bar'), 99);
 });
 
-
 test('.reset() - falsy `defaults` option', t => {
 	const store = new Conf({
 		cwd: tempy.directory(),
@@ -133,7 +132,7 @@ test('.reset() - falsy `defaults` option', t => {
 			foz: undefined,
 			baz: null,
 			fox: false,
-			bax: true,
+			bax: true
 		}
 	});
 
@@ -148,8 +147,7 @@ test('.reset() - falsy `defaults` option', t => {
 
 	t.is(store.get('foo'), 0);
 	t.is(store.get('bar'), '');
-	t.is(store.get('foz'), undefined);
-	t.is(store.get('baz'), undefined);
+	t.is(store.get('foz'), undefined); // eslint-disable-line @typescript-eslint/no-confusing-void-expression
 	t.is(store.get('fox'), false);
 	t.is(store.get('bax'), true);
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -124,30 +124,35 @@ test('.reset() - `defaults` option', t => {
 });
 
 test('.reset() - falsy `defaults` option', t => {
+	const defaultsValue: {
+		foo: number,
+		bar: string,
+		foz: undefined | string,
+		fox: boolean,
+		bax: boolean
+	} = {
+		foo: 0,
+		bar: '',
+		foz: undefined,
+		fox: false,
+		bax: true
+	};
 	const store = new Conf({
 		cwd: tempy.directory(),
-		defaults: {
-			foo: 0,
-			bar: '',
-			foz: undefined,
-			baz: null,
-			fox: false,
-			bax: true
-		}
+		defaults: defaultsValue
 	});
 
 	store.set('foo', 5);
 	store.set('bar', 'exist');
 	store.set('foz', 'string');
-	store.set('baz', 99);
 	store.set('fox', true);
 	store.set('fox', false);
 
-	store.reset('foo', 'bar', 'foz', 'baz', 'fox', 'bax');
+	store.reset('foo', 'bar', 'foz', 'fox', 'bax');
 
 	t.is(store.get('foo'), 0);
 	t.is(store.get('bar'), '');
-	t.is(store.get('foz'), undefined); // eslint-disable-line @typescript-eslint/no-confusing-void-expression
+	t.is(store.get('foz'), undefined);
 	t.is(store.get('fox'), false);
 	t.is(store.get('bax'), true);
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -123,6 +123,37 @@ test('.reset() - `defaults` option', t => {
 	t.is(store.get('bar'), 99);
 });
 
+
+test('.reset() - falsy `defaults` option', t => {
+	const store = new Conf({
+		cwd: tempy.directory(),
+		defaults: {
+			foo: 0,
+			bar: '',
+			foz: undefined,
+			baz: null,
+			fox: false,
+			bax: true,
+		}
+	});
+
+	store.set('foo', 5);
+	store.set('bar', 'exist');
+	store.set('foz', 'string');
+	store.set('baz', 99);
+	store.set('fox', true);
+	store.set('fox', false);
+
+	store.reset('foo', 'bar', 'foz', 'baz', 'fox', 'bax');
+
+	t.is(store.get('foo'), 0);
+	t.is(store.get('bar'), '');
+	t.is(store.get('foz'), undefined);
+	t.is(store.get('baz'), undefined);
+	t.is(store.get('fox'), false);
+	t.is(store.get('bax'), true);
+});
+
 test('.reset() - `schema` option', t => {
 	const store = new Conf({
 		cwd: tempy.directory(),


### PR DESCRIPTION
# Problem

Currently condition to use whether default value or undefined, is not accuracy.

```js
if (value) {

}
```

The if condition with plain object in condition field will return false on falsy value including zero number (0), empty string (""), and false value of boolean (false). which on this case it might be actual default value.

# Solution

So I create new function to help checking existing of variable which will check only not undefined and not null value