### PR TITLE
Fix issue with `onDidChange` not always being called

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -488,7 +488,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 		} else {
 			fs.watchFile(this.path, {persistent: false}, debounceFn(() => {
 				this.events.emit('change');
-			}, {wait: 100}));
+			}, {wait: 5000}));
 		}
 	}
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -488,7 +488,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 		} else {
 			fs.watchFile(this.path, {persistent: false}, debounceFn(() => {
 				this.events.emit('change');
-			}, {wait: 7000}));
+			}, {wait: 5000}));
 		}
 	}
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -480,10 +480,16 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 			this._write(createPlainObject<T>());
 		}
 
-		fs.watch(this.path, {persistent: false}, debounceFn(() => {
+		if (process.platform === 'win32') {
+			fs.watch(this.path, {persistent: false}, debounceFn(() => {
 			// On Linux and Windows, writing to the config file emits a `rename` event, so we skip checking the event type.
-			this.events.emit('change');
-		}, {wait: 100}));
+				this.events.emit('change');
+			}, {wait: 100}));
+		} else {
+			fs.watchFile(this.path, {persistent: false}, debounceFn(() => {
+				this.events.emit('change');
+			}, {wait: 100}));
+		}
 	}
 
 	private _migrate(migrations: Migrations<T>, versionToMigrate: string): void {

--- a/source/index.ts
+++ b/source/index.ts
@@ -488,7 +488,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 		} else {
 			fs.watchFile(this.path, {persistent: false}, debounceFn(() => {
 				this.events.emit('change');
-			}, {wait: 5000}));
+			}, {wait: 7000}));
 		}
 	}
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -848,9 +848,7 @@ test('.delete() - without dot notation', t => {
 	t.deepEqual(configWithoutDotNotation.get('foo.bar.zoo'), {awesome: 'redpanda'});
 });
 
-const test2 = process.platform === 'darwin' ? test.failing : test;
-
-test2('`watch` option watches for config file changes by another process', async t => {
+test('`watch` option watches for config file changes by another process', async t => {
 	const cwd = tempy.directory();
 	const conf1 = new Conf({cwd, watch: true});
 	const conf2 = new Conf({cwd});
@@ -877,7 +875,7 @@ test2('`watch` option watches for config file changes by another process', async
 	await pEvent(_events, 'change');
 });
 
-test2('`watch` option watches for config file changes by file write', async t => {
+test('`watch` option watches for config file changes by file write', async t => {
 	const cwd = tempy.directory();
 	const conf = new Conf({cwd, watch: true});
 	conf.set('foo', '🐴');
@@ -892,7 +890,7 @@ test2('`watch` option watches for config file changes by file write', async t =>
 	conf.onDidChange('foo', checkFoo);
 
 	(async () => {
-		await delay(5000);
+		await delay(7000);
 		fs.writeFileSync(path.join(cwd, 'config.json'), JSON.stringify({foo: '🦄'}));
 	})();
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -848,7 +848,8 @@ test('.delete() - without dot notation', t => {
 	t.deepEqual(configWithoutDotNotation.get('foo.bar.zoo'), {awesome: 'redpanda'});
 });
 
-const test2 = process.platform === 'darwin' ? test.failing : test;
+/* eslint no-negated-condition: 0 */
+const test2 = process.platform !== 'win32' ? test.failing : test;
 
 test2('`watch` option watches for config file changes by another process', async t => {
 	const cwd = tempy.directory();

--- a/test/index.ts
+++ b/test/index.ts
@@ -848,8 +848,7 @@ test('.delete() - without dot notation', t => {
 	t.deepEqual(configWithoutDotNotation.get('foo.bar.zoo'), {awesome: 'redpanda'});
 });
 
-/* eslint no-negated-condition: 0 */
-const test2 = process.platform !== 'win32' ? test.failing : test;
+const test2 = process.platform === 'darwin' ? test.failing : test;
 
 test2('`watch` option watches for config file changes by another process', async t => {
 	const cwd = tempy.directory();
@@ -893,7 +892,7 @@ test2('`watch` option watches for config file changes by file write', async t =>
 	conf.onDidChange('foo', checkFoo);
 
 	(async () => {
-		await delay(50);
+		await delay(5000);
 		fs.writeFileSync(path.join(cwd, 'config.json'), JSON.stringify({foo: '🦄'}));
 	})();
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -889,8 +889,11 @@ test('`watch` option watches for config file changes by file write', async t => 
 
 	conf.onDidChange('foo', checkFoo);
 
+	const delayOS = process.platform === 'win32' ? 50 : 5000;
+
 	(async () => {
-		await delay(7000);
+		await delay(delayOS);
+
 		fs.writeFileSync(path.join(cwd, 'config.json'), JSON.stringify({foo: '🦄'}));
 	})();
 


### PR DESCRIPTION
Fixes #108 and fixes https://github.com/sindresorhus/electron-store/issues/93

Adds a configuration option called `watchFile`.

Works exactly like `watch` but uses `fs.watchFile` instead of `fs.watch`, allowing the subscription to read changes in the file more than once.

```jsx
useEffect(()=>{
    store.onDidChange('myKey', (newV, oldV) => {
      console.log(`Changed from ${oldV} to ${newV}`)
    })
},[])
```

![image](https://user-images.githubusercontent.com/50466554/107242228-0cc0cf80-6a2c-11eb-8abc-a897da42ee91.png)

Clearly slower (sometimes, benchmarking is unreliable 100/2000ms) than `watch` but the only way to truly watch a file in React (and possible other scenarios, but not tested).
