### PR TITLE
Add ajv-formats when a schema is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 	],
 	"dependencies": {
 		"ajv": "^7.0.3",
+		"ajv-formats": "^1.5.1",
 		"atomically": "^1.7.0",
 		"debounce-fn": "^4.0.0",
 		"dot-prop": "^6.0.1",

--- a/source/index.ts
+++ b/source/index.ts
@@ -9,6 +9,7 @@ import pkgUp = require('pkg-up');
 import envPaths = require('env-paths');
 import atomically = require('atomically');
 import Ajv, {ValidateFunction as AjvValidateFunction} from 'ajv';
+import ajvFormats from 'ajv-formats';
 import debounceFn = require('debounce-fn');
 import semver = require('semver');
 import onetime = require('onetime');
@@ -97,6 +98,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 				allErrors: true,
 				useDefaults: true
 			});
+			ajvFormats(ajv);
 
 			const schema: JSONSchema = {
 				type: 'object',

--- a/test/index.ts
+++ b/test/index.ts
@@ -723,6 +723,21 @@ test('schema - complex schema', t => {
 	}, {message: 'Config schema violation: `bar` should NOT have more than 3 items; `bar/3` should be integer; `bar` should NOT have duplicate items (items ## 1 and 0 are identical)'});
 });
 
+test('schema - supports formats', t => {
+	const config = new Conf({
+		cwd: tempy.directory(),
+		schema: {
+			foo: {
+				type: 'string',
+				format: 'uri'
+			}
+		}
+	});
+	t.throws(() => {
+		config.set('foo', 'bar');
+	}, {message: 'Config schema violation: `foo` should match format "uri"'});
+});
+
 test('schema - invalid write to config file', t => {
 	const schema: Schema<{foo: string}> = {
 		foo: {


### PR DESCRIPTION
This PR fixes #140 by adding a dependency on `ajv-formats`, and adding the formats to the `Ajv` instance used to validate configs against the `schema` option.

A test has been added to catch the issue, and I don't think any documentation changes are necessary since the README already claims that it's possible to use AJV's formats.