### PR TITLE
Wrap require-cache part with try-catch

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -33,7 +33,7 @@ try {
 // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
 	delete require.cache[__filename];
 	parentDir = path.dirname(module.parent?.filename ?? '.');
-}catch(e){}
+} catch {}
 
 const checkValueType = (key: string, value: unknown): void => {
 	const nonJsonTypes = new Set([

--- a/source/index.ts
+++ b/source/index.ts
@@ -26,10 +26,14 @@ const isExist = <T = unknown>(data: T): boolean => {
 	return data !== undefined && data !== null;
 };
 
-// Prevent caching of this module so module.parent is always accurate
+let parentDir = '';
+try {
+// Prevent caching of this module so module.parent is always accurate.
+// Note: This trick won't work with ESM or inside a webworker
 // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-delete require.cache[__filename];
-const parentDir = path.dirname(module.parent?.filename ?? '.');
+	delete require.cache[__filename];
+	parentDir = path.dirname(module.parent?.filename ?? '.');
+}catch(e){}
 
 const checkValueType = (key: string, value: unknown): void => {
 	const nonJsonTypes = new Set([


### PR DESCRIPTION
Resolves #145 .

This PR allows to use `conf` inside a webworker and prevent the app from crashing.
As described in #145 , this is a quick-win solution which will allow to use conf easily from inside the webworker, later iteration will be needed to remove the part of `module.parent` and `require.cache[__filename]` entirely.  