### PR TITLE
Avoid invoking store getter twice

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -182,7 +182,8 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 			return this._get(key, defaultValue);
 		}
 
-		return key in this.store ? this.store[key] : defaultValue;
+		const {store} = this;
+		return key in store ? store[key] : defaultValue;
 	}
 
 	/**


### PR DESCRIPTION
```
if (this.#options.accessPropertiesByDotNotation) {
    return this._get(key, defaultValue);
}

return key in this.store ? this.store[key] : defaultValue;
```

If `accessPropertiesByDotNotation == false` && `key in this.store == true`, then getter `get store()` will be run twice.
1. `key in this.store` 
2. `this.store[key]`