### PR TITLE
Add `configFileMode` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -192,6 +192,17 @@ Default: `false`
 
 The config is cleared if reading the config file causes a `SyntaxError`. This is a good behavior for unimportant data, as the config file is not intended to be hand-edited, so it usually means the config is corrupt and there's nothing the user can do about it anyway. However, if you let the user edit the config file directly, mistakes might happen and it could be more useful to throw an error when the config is invalid instead of clearing.
 
+#### configFileMode
+
+Type: `number`\
+Default: `0o666`
+
+The [mode](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) that will be used for the config file.
+
+You would usually not need this, but it could be useful if you want to restrict the permissions of the configuration file. Setting a permission such as 0o600 would result in a configuration file that can only be accessed by the user running the program.
+
+Note that setting restrictive permissions can cause problems if multiple different users need to read the file.
+
 #### serialize
 
 Type: `Function`\

--- a/readme.md
+++ b/readme.md
@@ -192,17 +192,6 @@ Default: `false`
 
 The config is cleared if reading the config file causes a `SyntaxError`. This is a good behavior for unimportant data, as the config file is not intended to be hand-edited, so it usually means the config is corrupt and there's nothing the user can do about it anyway. However, if you let the user edit the config file directly, mistakes might happen and it could be more useful to throw an error when the config is invalid instead of clearing.
 
-#### configFileMode
-
-Type: `number`\
-Default: `0o666`
-
-The [mode](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) that will be used for the config file.
-
-You would usually not need this, but it could be useful if you want to restrict the permissions of the configuration file. Setting a permission such as 0o600 would result in a configuration file that can only be accessed by the user running the program.
-
-Note that setting restrictive permissions can cause problems if multiple different users need to read the file.
-
 #### serialize
 
 Type: `Function`\
@@ -279,6 +268,17 @@ type: `boolean`\
 Default: `false`
 
 Watch for any changes in the config file and call the callback for `onDidChange` or `onDidAnyChange` if set. This is useful if there are multiple processes changing the same config file.
+
+#### configFileMode
+
+Type: `number`\
+Default: `0o666`
+
+The [mode](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) that will be used for the config file.
+
+You would usually not need this, but it could be useful if you want to restrict the permissions of the config file. Setting a permission such as `0o600` would result in a config file that can only be accessed by the user running the program.
+
+Note that setting restrictive permissions can cause problems if different users need to read the file. A common problem is a user running your tool with and without `sudo` and then not being able to access the config the second time.
 
 ### Instance
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -67,7 +67,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 			projectSuffix: 'nodejs',
 			clearInvalidConfig: false,
 			accessPropertiesByDotNotation: true,
-			mode: 0o666,
+			configFileMode: 0o666,
 			...partialOptions
 		};
 
@@ -462,16 +462,16 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 		// Temporary workaround for Conf being packaged in a Ubuntu Snap app.
 		// See https://github.com/sindresorhus/conf/pull/82
 		if (process.env.SNAP) {
-			fs.writeFileSync(this.path, data, { mode: this.#options.mode});
+			fs.writeFileSync(this.path, data, {mode: this.#options.configFileMode});
 		} else {
 			try {
-				atomically.writeFileSync(this.path, data, { mode: this.#options.mode});
+				atomically.writeFileSync(this.path, data, {mode: this.#options.configFileMode});
 			} catch (error: any) {
 				// Fix for https://github.com/sindresorhus/electron-store/issues/106
 				// Sometimes on Windows, we will get an EXDEV error when atomic writing
 				// (even though to the same directory), so we fall back to non atomic write
 				if (error?.code === 'EXDEV') {
-					fs.writeFileSync(this.path, data, { mode: this.#options.mode});
+					fs.writeFileSync(this.path, data, {mode: this.#options.configFileMode});
 					return;
 				}
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -67,6 +67,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 			projectSuffix: 'nodejs',
 			clearInvalidConfig: false,
 			accessPropertiesByDotNotation: true,
+			mode: 0o666,
 			...partialOptions
 		};
 
@@ -461,16 +462,16 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 		// Temporary workaround for Conf being packaged in a Ubuntu Snap app.
 		// See https://github.com/sindresorhus/conf/pull/82
 		if (process.env.SNAP) {
-			fs.writeFileSync(this.path, data);
+			fs.writeFileSync(this.path, data, { mode: this.#options.mode});
 		} else {
 			try {
-				atomically.writeFileSync(this.path, data);
+				atomically.writeFileSync(this.path, data, { mode: this.#options.mode});
 			} catch (error: any) {
 				// Fix for https://github.com/sindresorhus/electron-store/issues/106
 				// Sometimes on Windows, we will get an EXDEV error when atomic writing
 				// (even though to the same directory), so we fall back to non atomic write
 				if (error?.code === 'EXDEV') {
-					fs.writeFileSync(this.path, data);
+					fs.writeFileSync(this.path, data, { mode: this.#options.mode});
 					return;
 				}
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -138,11 +138,15 @@ export interface Options<T> {
 	clearInvalidConfig?: boolean;
 
 	/**
-	The mode that will be used for the config file.
+	The [mode](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) that will be used for the config file.
+
+	You would usually not need this, but it could be useful if you want to restrict the permissions of the configuration file. Setting a permission such as 0o600 would result in a configuration file that can only be accessed by the user running the program.
+
+	Note that setting restrictive permissions can cause problems if multiple different users need to read the file.
 
 	@default 0o666
 	*/
-	mode: number | string;
+	configFileMode: number;
 
 	/**
 	Function to serialize the config object to a UTF-8 string when writing the config file.

--- a/source/types.ts
+++ b/source/types.ts
@@ -212,7 +212,7 @@ export interface Options<T> {
 	@default false
 	*/
 	readonly watch?: boolean;
-	
+
 	/**
 	The [mode](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) that will be used for the config file.
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -138,6 +138,13 @@ export interface Options<T> {
 	clearInvalidConfig?: boolean;
 
 	/**
+	The mode that will be used for the config file.
+
+	@default 0o666
+	*/
+	mode: number | string;
+
+	/**
 	Function to serialize the config object to a UTF-8 string when writing the config file.
 
 	You would usually not need this, but it could be useful if you want to use a format other than JSON.

--- a/source/types.ts
+++ b/source/types.ts
@@ -138,17 +138,6 @@ export interface Options<T> {
 	clearInvalidConfig?: boolean;
 
 	/**
-	The [mode](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) that will be used for the config file.
-
-	You would usually not need this, but it could be useful if you want to restrict the permissions of the configuration file. Setting a permission such as 0o600 would result in a configuration file that can only be accessed by the user running the program.
-
-	Note that setting restrictive permissions can cause problems if multiple different users need to read the file.
-
-	@default 0o666
-	*/
-	configFileMode: number;
-
-	/**
 	Function to serialize the config object to a UTF-8 string when writing the config file.
 
 	You would usually not need this, but it could be useful if you want to use a format other than JSON.
@@ -223,6 +212,17 @@ export interface Options<T> {
 	@default false
 	*/
 	readonly watch?: boolean;
+	
+	/**
+	The [mode](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) that will be used for the config file.
+
+	You would usually not need this, but it could be useful if you want to restrict the permissions of the config file. Setting a permission such as `0o600` would result in a config file that can only be accessed by the user running the program.
+
+	Note that setting restrictive permissions can cause problems if different users need to read the file. A common problem is a user running your tool with and without `sudo` and then not being able to access the config the second time.
+
+	@default 0o666
+	*/
+	readonly configFileMode: number;
 }
 
 export type Migrations<T> = Record<string, (store: Conf<T>) => void>;

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -26,7 +26,7 @@ new Conf<UnicornFoo>({encryptionKey: Buffer.from('')});
 new Conf<UnicornFoo>({encryptionKey: new Uint8Array([1])});
 new Conf<UnicornFoo>({encryptionKey: new DataView(new ArrayBuffer(2))});
 new Conf<UnicornFoo>({fileExtension: '.foo'});
-new Conf<UnicornFoo>({ mode: 0o600 });
+new Conf<UnicornFoo>({configFileMode: 0o600});
 new Conf<UnicornFoo>({clearInvalidConfig: false});
 new Conf<UnicornFoo>({serialize: () => 'foo'});
 new Conf<UnicornFoo>({deserialize: () => ({foo: 'foo', unicorn: true})});

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -26,6 +26,7 @@ new Conf<UnicornFoo>({encryptionKey: Buffer.from('')});
 new Conf<UnicornFoo>({encryptionKey: new Uint8Array([1])});
 new Conf<UnicornFoo>({encryptionKey: new DataView(new ArrayBuffer(2))});
 new Conf<UnicornFoo>({fileExtension: '.foo'});
+new Conf<UnicornFoo>({ mode: 0o600 });
 new Conf<UnicornFoo>({clearInvalidConfig: false});
 new Conf<UnicornFoo>({serialize: () => 'foo'});
 new Conf<UnicornFoo>({deserialize: () => ({foo: 'foo', unicorn: true})});


### PR DESCRIPTION
This is a proposed implementation for #157. This adds a `mode` option, which is passed through to the underlying call to `fs.writeFileSync` or `atomically.writeFileSync`.

The default mode here (`0o666`) is the default mode for both `fs.writeFileSync` and `atomically.writeFileSync` so this should be a backwards-compatible change.