### PR TITLE
Fix the `configFileMode` option for TypeScript

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -222,7 +222,7 @@ export interface Options<T> {
 
 	@default 0o666
 	*/
-	readonly configFileMode: number;
+	readonly configFileMode?: number;
 }
 
 export type Migrations<T> = Record<string, (store: Conf<T>) => void>;


### PR DESCRIPTION
PR #158 added a new option, but improperly set up the typescript type. Now, all typescript applications which try and use `conf` run into something like this:
```
error TS2345: Argument of type '{ watch: true; }' is not assignable to parameter of type 'Options<Record<string, unknown>>'.
  Property 'configFileMode' is missing in type '{ watch: true; }' but required in type 'Except<Options<Record<string, unknown>>, "configName" | "projectName" | "projectVersion" | "projectSuffix">'.
```
during typescript compilation. This PR fixes this by properly marking the option as optional.