### PR TITLE
beforeMigration option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,11 +136,9 @@ const store = new Conf({
 Type: `Function`\
 Default: `undefined`
 
-You can use `beforeEachMigration` callback for logging purposes, preparing migration data, etc.
+The given callback function will be called before each migration step.
 
-`beforeEachMigration` callback will be called before each migrations executed.
-
-It could be useful when you have multiple configs and you want to log the migration data for each config.
+This can be useful for logging purposes, preparing migration data, etc.
 
 Example:
 

--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,7 @@ const mainConfig = new Conf({
 		},
 	}
 });
+
 const secondConfig = new Conf({
 	beforeEachMigration: (store, context) => {
 		console.log(`[second-config] migrate from ${context.fromVersion} → ${context.toVersion}`);

--- a/readme.md
+++ b/readme.md
@@ -131,16 +131,16 @@ const store = new Conf({
 
 > Note: The version the migrations use refers to the **project version** by default. If you want to change this behavior, specify the [`projectVersion`](#projectVersion) option.
 
-### beforeMigration
+### beforeEachMigration
 
 Type: `Function`\
 Default: `undefined`
 
-You can use `beforeMigration` callback for logging purposes, preparing migration data, etc.
+You can use `beforeEachMigration` callback for logging purposes, preparing migration data, etc.
 
-`beforeMigration` callback will be called before the migration is executed.
+`beforeEachMigration` callback will be called before each migrations executed.
 
-It could be useful when u have multiple configs and you want to log the migration data for each config.
+It could be useful when you have multiple configs and you want to log the migration data for each config.
 
 Example:
 
@@ -150,8 +150,8 @@ const Conf = require('conf');
 console.log = someLogger.log;
 
 const mainConfig = new Conf({
-	beforeMigration: (store, currentVersion, nextVersion) => {
-		console.log(`[main-config] migrate from ${currentVersion} -> ${nextVersion}`);
+	beforeEachMigration: (store, context) => {
+		console.log(`[main-config] migrate from ${context.fromVersion} → ${context.toVersion}`);
 	},
 	migrations: {
 		'0.4.0': store => {
@@ -160,8 +160,8 @@ const mainConfig = new Conf({
 	}
 });
 const secondConfig = new Conf({
-	beforeMigration: (store, currentVersion, nextVersion) => {
-		console.log(`[second-config] migrate from ${currentVersion} -> ${nextVersion}`);
+	beforeEachMigration: (store, context) => {
+		console.log(`[second-config] migrate from ${context.fromVersion} → ${context.toVersion}`);
 	},
 	migrations: {
 		'1.0.1': store => {

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,46 @@ const store = new Conf({
 
 > Note: The version the migrations use refers to the **project version** by default. If you want to change this behavior, specify the [`projectVersion`](#projectVersion) option.
 
+### beforeMigration
+
+Type: `Function`\
+Default: `undefined`
+
+You can use `beforeMigration` callback for logging purposes, preparing migration data, etc.
+
+`beforeMigration` callback will be called before the migration is executed.
+
+It could be useful when u have multiple configs and you want to log the migration data for each config.
+
+Example:
+
+```js
+const Conf = require('conf');
+
+console.log = someLogger.log;
+
+const mainConfig = new Conf({
+	beforeMigration: (store, currentVersion, nextVersion) => {
+		console.log(`[main-config] migrate from ${currentVersion} -> ${nextVersion}`);
+	},
+	migrations: {
+		'0.4.0': store => {
+			store.set('debugPhase', true);
+		},
+	}
+});
+const secondConfig = new Conf({
+	beforeMigration: (store, currentVersion, nextVersion) => {
+		console.log(`[second-config] migrate from ${currentVersion} -> ${nextVersion}`);
+	},
+	migrations: {
+		'1.0.1': store => {
+			store.set('debugPhase', true);
+		},
+	}
+});
+```
+
 #### configName
 
 Type: `string`\

--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,13 @@ Default: `undefined`
 
 The given callback function will be called before each migration step.
 
+The function receives the store as the first argument and a context object as the second argument with the following properties:
+
+- `fromVersion` - The version the migration step is being migrated from.
+- `toVersion` - The version the migration step is being migrated to.
+- `finalVersion` - The final version after all the migrations are applied.
+- `versions` - All the versions with a migration step.
+
 This can be useful for logging purposes, preparing migration data, etc.
 
 Example:

--- a/source/index.ts
+++ b/source/index.ts
@@ -14,7 +14,7 @@ import debounceFn = require('debounce-fn');
 import semver = require('semver');
 import onetime = require('onetime');
 import {JSONSchema} from 'json-schema-typed';
-import {Deserialize, Migrations, OnDidChangeCallback, Options, Serialize, Unsubscribe, Schema, OnDidAnyChangeCallback, BeforeMigrationCallback} from './types';
+import {Deserialize, Migrations, OnDidChangeCallback, Options, Serialize, Unsubscribe, Schema, OnDidAnyChangeCallback, BeforeEachMigrationCallback} from './types';
 
 const encryptionAlgorithm = 'aes-256-cbc';
 
@@ -163,7 +163,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 				throw new Error('Project version could not be inferred. Please specify the `projectVersion` option.');
 			}
 
-			this._migrate(options.migrations, options.projectVersion, options.beforeMigration);
+			this._migrate(options.migrations, options.projectVersion, options.beforeEachMigration);
 		}
 	}
 
@@ -499,7 +499,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 		}
 	}
 
-	private _migrate(migrations: Migrations<T>, versionToMigrate: string, beforeMigration?: BeforeMigrationCallback<T>): void {
+	private _migrate(migrations: Migrations<T>, versionToMigrate: string, beforeEachMigration?: BeforeEachMigrationCallback<T>): void {
 		let previousMigratedVersion = this._get(MIGRATION_KEY, '0.0.0');
 
 		const newerVersions = Object.keys(migrations)
@@ -509,8 +509,8 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 
 		for (const version of newerVersions) {
 			try {
-				if (beforeMigration) {
-					beforeMigration(this, previousMigratedVersion, version);
+				if (beforeEachMigration) {
+					beforeEachMigration(this, {fromVersion: previousMigratedVersion, toVersion: version});
 				}
 
 				const migration = migrations[version];

--- a/source/index.ts
+++ b/source/index.ts
@@ -510,7 +510,14 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 		for (const version of newerVersions) {
 			try {
 				if (beforeEachMigration) {
-					beforeEachMigration(this, {fromVersion: previousMigratedVersion, toVersion: version});
+					beforeEachMigration(this, {
+						fromVersion: previousMigratedVersion,
+						toVersion: version,
+						migrationProcess: {
+							finalVersion: versionToMigrate,
+							versions: newerVersions
+						}
+					});
 				}
 
 				const migration = migrations[version];

--- a/source/index.ts
+++ b/source/index.ts
@@ -513,10 +513,8 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 					beforeEachMigration(this, {
 						fromVersion: previousMigratedVersion,
 						toVersion: version,
-						migrationProcess: {
-							finalVersion: versionToMigrate,
-							versions: newerVersions
-						}
+						finalVersion: versionToMigrate,
+						versions: newerVersions
 					});
 				}
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -14,11 +14,11 @@ import debounceFn = require('debounce-fn');
 import semver = require('semver');
 import onetime = require('onetime');
 import {JSONSchema} from 'json-schema-typed';
-import {Deserialize, Migrations, OnDidChangeCallback, Options, Serialize, Unsubscribe, Schema, OnDidAnyChangeCallback} from './types';
+import {Deserialize, Migrations, OnDidChangeCallback, Options, Serialize, Unsubscribe, Schema, OnDidAnyChangeCallback, BeforeMigrationCallback} from './types';
 
 const encryptionAlgorithm = 'aes-256-cbc';
 
-const createPlainObject = <T = unknown>(): T => {
+const createPlainObject = <T = Record<string, unknown>>(): T => {
 	return Object.create(null);
 };
 
@@ -141,7 +141,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 		this.path = path.resolve(options.cwd, `${options.configName ?? 'config'}${fileExtension}`);
 
 		const fileStore = this.store;
-		const store = Object.assign(createPlainObject<T>(), options.defaults, fileStore);
+		const store = Object.assign(createPlainObject(), options.defaults, fileStore);
 		this._validate(store);
 
 		try {
@@ -163,7 +163,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 				throw new Error('Project version could not be inferred. Please specify the `projectVersion` option.');
 			}
 
-			this._migrate(options.migrations, options.projectVersion);
+			this._migrate(options.migrations, options.projectVersion, options.beforeMigration);
 		}
 	}
 
@@ -499,7 +499,7 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 		}
 	}
 
-	private _migrate(migrations: Migrations<T>, versionToMigrate: string): void {
+	private _migrate(migrations: Migrations<T>, versionToMigrate: string, beforeMigration?: BeforeMigrationCallback<T>): void {
 		let previousMigratedVersion = this._get(MIGRATION_KEY, '0.0.0');
 
 		const newerVersions = Object.keys(migrations)
@@ -509,6 +509,10 @@ class Conf<T extends Record<string, any> = Record<string, unknown>> implements I
 
 		for (const version of newerVersions) {
 			try {
+				if (beforeMigration) {
+					beforeMigration(this, previousMigratedVersion, version);
+				}
+
 				const migration = migrations[version];
 				migration(this);
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -104,11 +104,9 @@ export interface Options<T extends Record<string, any>> {
 	migrations?: Migrations<T>;
 
 	/**
-	You can use `beforeEachMigration` callback for logging purposes, preparing migration data, etc.
+	The given callback function will be called before each migration step.
 
-	`beforeEachMigration` callback will be called before the migration is executed.
-
-	It could be useful when you have multiple configs and you want to log the migration data for each config.
+	This can be useful for logging purposes, preparing migration data, etc.
 	*/
 	beforeEachMigration?: BeforeEachMigrationCallback<T>;
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -109,7 +109,6 @@ export interface Options<T extends Record<string, any>> {
 	`beforeEachMigration` callback will be called before the migration is executed.
 
 	It could be useful when you have multiple configs and you want to log the migration data for each config.
-
 	*/
 	beforeEachMigration?: BeforeEachMigrationCallback<T>;
 
@@ -240,10 +239,8 @@ export type Migrations<T extends Record<string, any>> = Record<string, (store: C
 export type BeforeEachMigrationContext = {
 	fromVersion: string;
 	toVersion: string;
-	migrationProcess: {
-		finalVersion: string;
-		versions: string[];
-	};
+	finalVersion: string;
+	versions: string[];
 };
 export type BeforeEachMigrationCallback<T extends Record<string, any>> = (store: Conf<T>, context: BeforeEachMigrationContext) => void;
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -104,6 +104,16 @@ export interface Options<T extends Record<string, any>> {
 	migrations?: Migrations<T>;
 
 	/**
+	You can use `beforeMigration` callback for logging purposes, preparing migration data, etc.
+
+	`beforeMigration` callback will be called before the migration is executed.
+
+	It could be useful when u have multiple configs and you want to log the migration data for each config.
+
+	*/
+	beforeMigration?: BeforeMigrationCallback<T>;
+
+	/**
 	__You most likely don't need this. Please don't use it unless you really have to.__
 
 	The only use-case I can think of is having the config located in the app directory or on some external storage. Default: System default user [config directory](https://github.com/sindresorhus/env-paths#pathsconfig).
@@ -226,6 +236,7 @@ export interface Options<T extends Record<string, any>> {
 }
 
 export type Migrations<T extends Record<string, any>> = Record<string, (store: Conf<T>) => void>;
+export type BeforeMigrationCallback<T extends Record<string, any>> = (store: Conf<T>, currentVersion: string, previousVersion: string) => void;
 
 export type Schema<T> = {[Property in keyof T]: ValueSchema};
 export type ValueSchema = TypedJSONSchema;

--- a/source/types.ts
+++ b/source/types.ts
@@ -104,14 +104,14 @@ export interface Options<T extends Record<string, any>> {
 	migrations?: Migrations<T>;
 
 	/**
-	You can use `beforeMigration` callback for logging purposes, preparing migration data, etc.
+	You can use `beforeEachMigration` callback for logging purposes, preparing migration data, etc.
 
-	`beforeMigration` callback will be called before the migration is executed.
+	`beforeEachMigration` callback will be called before the migration is executed.
 
-	It could be useful when u have multiple configs and you want to log the migration data for each config.
+	It could be useful when you have multiple configs and you want to log the migration data for each config.
 
 	*/
-	beforeMigration?: BeforeMigrationCallback<T>;
+	beforeEachMigration?: BeforeEachMigrationCallback<T>;
 
 	/**
 	__You most likely don't need this. Please don't use it unless you really have to.__
@@ -236,7 +236,12 @@ export interface Options<T extends Record<string, any>> {
 }
 
 export type Migrations<T extends Record<string, any>> = Record<string, (store: Conf<T>) => void>;
-export type BeforeMigrationCallback<T extends Record<string, any>> = (store: Conf<T>, currentVersion: string, previousVersion: string) => void;
+
+export type BeforeEachMigrationContext = {
+	fromVersion: string;
+	toVersion: string;
+};
+export type BeforeEachMigrationCallback<T extends Record<string, any>> = (store: Conf<T>, context: BeforeEachMigrationContext) => void;
 
 export type Schema<T> = {[Property in keyof T]: ValueSchema};
 export type ValueSchema = TypedJSONSchema;

--- a/source/types.ts
+++ b/source/types.ts
@@ -240,6 +240,10 @@ export type Migrations<T extends Record<string, any>> = Record<string, (store: C
 export type BeforeEachMigrationContext = {
 	fromVersion: string;
 	toVersion: string;
+	migrationProcess: {
+		finalVersion: string;
+		versions: string[];
+	};
 };
 export type BeforeEachMigrationCallback<T extends Record<string, any>> = (store: Conf<T>, context: BeforeEachMigrationContext) => void;
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -137,7 +137,7 @@ expectError<number>(config.get('unicorn', 1));
 new Conf({
 	beforeEachMigration: (store, context) => {
 		console.log(`[main-config] migrate from ${context.fromVersion} → ${context.toVersion}`);
-		console.log(`[main-config] final migration verison ${context.migrationProcess.finalVersion}, all migrations that were run or will be runned: ${context.migrationProcess.versions.toString()}`);
+		console.log(`[main-config] final migration version ${context.finalVersion}, all migrations that were run or will be ran: ${context.versions.toString()}`);
 		console.log(`[main-config] phase ${(store.get('phase') || 'none') as string}`);
 	},
 	migrations: {

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -137,6 +137,7 @@ expectError<number>(config.get('unicorn', 1));
 new Conf({
 	beforeEachMigration: (store, context) => {
 		console.log(`[main-config] migrate from ${context.fromVersion} → ${context.toVersion}`);
+		console.log(`[main-config] final migration verison ${context.migrationProcess.finalVersion}, all migrations that were run or will be runned: ${context.migrationProcess.versions.toString()}`);
 		console.log(`[main-config] phase ${(store.get('phase') || 'none') as string}`);
 	},
 	migrations: {

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -135,6 +135,10 @@ expectError<number>(config.get('unicorn', 1));
 
 // -- Migrations --
 new Conf({
+	beforeMigration: (store, currentVersion, nextVersion) => {
+		console.log(`[main-config] migrate from ${currentVersion} -> ${nextVersion}`);
+		console.log(`[main-config] phase ${(store.get('phase') || 'none') as string}`);
+	},
 	migrations: {
 		'0.0.1': store => {
 			store.set('debug phase', true);

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -135,8 +135,8 @@ expectError<number>(config.get('unicorn', 1));
 
 // -- Migrations --
 new Conf({
-	beforeMigration: (store, currentVersion, nextVersion) => {
-		console.log(`[main-config] migrate from ${currentVersion} -> ${nextVersion}`);
+	beforeEachMigration: (store, context) => {
+		console.log(`[main-config] migrate from ${context.fromVersion} → ${context.toVersion}`);
 		console.log(`[main-config] phase ${(store.get('phase') || 'none') as string}`);
 	},
 	migrations: {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1218,7 +1218,7 @@ test('beforeEachMigration - should be called before every migration', t => {
 		}
 	});
 
-	t.is(conf.get('beforeEachMigration 0.0.0 → 1.0.0'), true);
-	t.is(conf.get('beforeEachMigration 1.0.0 → 1.0.1'), true);
+	t.true(conf.get('beforeEachMigration 0.0.0 → 1.0.0'));
+	t.true(conf.get('beforeEachMigration 1.0.0 → 1.0.1'));
 	t.false(conf.has('beforeEachMigration 1.0.1 → 2.0.1'));
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -1203,3 +1203,22 @@ test('__internal__ keys - should only match specific "__internal__" entry', t =>
 		conf.set('__internal__foo.you-shall', 'not-pass');
 	});
 });
+
+test('beforeMigration - should be called before every migration', t => {
+	const conf = new Conf({
+		cwd: tempy.directory(),
+		projectVersion: '2.0.0',
+		beforeMigration: (store, currentVersion, nextVersion) => {
+			store.set(`beforeMigration ${currentVersion} -> ${nextVersion}`, true);
+		},
+		migrations: {
+			'1.0.0': () => {},
+			'1.0.1': () => {},
+			'2.0.1': () => {}
+		}
+	});
+
+	t.is(conf.get('beforeMigration 0.0.0 -> 1.0.0'), true);
+	t.is(conf.get('beforeMigration 1.0.0 -> 1.0.1'), true);
+	t.false(conf.has('beforeMigration 1.0.1 -> 2.0.1'));
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -1204,12 +1204,12 @@ test('__internal__ keys - should only match specific "__internal__" entry', t =>
 	});
 });
 
-test('beforeMigration - should be called before every migration', t => {
+test('beforeEachMigration - should be called before every migration', t => {
 	const conf = new Conf({
 		cwd: tempy.directory(),
 		projectVersion: '2.0.0',
-		beforeMigration: (store, currentVersion, nextVersion) => {
-			store.set(`beforeMigration ${currentVersion} -> ${nextVersion}`, true);
+		beforeEachMigration: (store, context) => {
+			store.set(`beforeEachMigration ${context.fromVersion} → ${context.toVersion}`, true);
 		},
 		migrations: {
 			'1.0.0': () => {},
@@ -1218,7 +1218,7 @@ test('beforeMigration - should be called before every migration', t => {
 		}
 	});
 
-	t.is(conf.get('beforeMigration 0.0.0 -> 1.0.0'), true);
-	t.is(conf.get('beforeMigration 1.0.0 -> 1.0.1'), true);
-	t.false(conf.has('beforeMigration 1.0.1 -> 2.0.1'));
+	t.is(conf.get('beforeEachMigration 0.0.0 → 1.0.0'), true);
+	t.is(conf.get('beforeEachMigration 1.0.0 → 1.0.1'), true);
+	t.false(conf.has('beforeEachMigration 1.0.1 → 2.0.1'));
 });


### PR DESCRIPTION
You can use `beforeMigration` callback for logging purposes, preparing migration data, etc.
`beforeMigration` callback will be called before the migration is executed.
It could be useful when u have multiple configs and you want to log the migration data for each config.

My example - I use multiple `electron-store`'s and its usefull to log all migrations via `electron-log` in single file for debugging purposes, its easier to understand what can cause issue. Probably its can be usefull for others

```ts
import Conf from 'conf';

console.log = someLogger.log;

const mainConfig = new Conf({
	beforeMigration: (store, currentVersion, nextVersion) => {
		console.log(`[main-config] migrate from ${currentVersion} -> ${nextVersion}`);
	},
	migrations: {
		'0.4.0': store => {
		   // somethign that might broke config silently
        },
	}
});

const secondConfig = new Conf({
	beforeMigration: (store, currentVersion, nextVersion) => {
		console.log(`[second-config] migrate from ${currentVersion} -> ${nextVersion}`);
	},
	migrations: {
		'1.0.1': store => {
          // somethign that might broke config silently
        },
	}
});
```