### PR TITLE
Fix paths in `package.json`'s exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 	},
 	"type": "module",
 	"exports": {
-		"types": "./dist/index.d.ts",
-		"default": "./dist/index.js"
+		"types": "./dist/source/index.d.ts",
+		"default": "./dist/source/index.js"
 	},
 	"engines": {
 		"node": ">=14.16"


### PR DESCRIPTION
Trying to use the ESM version of Conf I noticed imports and types could not get resolved by Typescript. It turns out that [the paths](https://github.com/sindresorhus/conf/commit/cea3d686ec7f7a940ea74b6d719f069efc1c80f0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R15-R16) in the `package.json` are not the right ones. I'm updating them in this PR.
Would it be possible to do a patch release once this PR gets merged?
Thanks 🙏🏼 