### PR TITLE
Fixed TypeScript TS2307 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"types": "./dist/source/index.d.ts",
 		"default": "./dist/source/index.js"
 	},
+	"types": "./dist/source/index.d.ts",
+	"main": "./dist/source/index.js",
 	"engines": {
 		"node": ">=14.16"
 	},


### PR DESCRIPTION
Typescript reports the following error 

TS2307: Cannot find module 'conf' or its corresponding type declarations

This is because the package.json is missing a types or main filed.

`
  "types": "./dist/source/index.d.ts",
  "main": "./dist/source/index.js",
`
Without these fields **tsc --build  --traceResolution** results in the below

> Found 'package.json' at 'C:/Users/******/node_modules/conf/package.json'.
> 'package.json' does not have a 'typesVersions' field.
> File 'C:/Users/******/node_modules/conf.ts' does not exist.
> File 'C:/Users/******/node_modules/conf.tsx' does not exist.
> File 'C:/Users/******/node_modules/conf.d.ts' does not exist.
> 'package.json' does not have a 'typings' field.
> 'package.json' does not have a 'types' field.
> 'package.json' does not have a 'main' field.

While there is an exports filed in the current package.json

`
  "exports": {
    "types": "./dist/source/index.d.ts",
    "default": "./dist/source/index.js"
  }
`

It appears this is ignored unless Typescripts  moduleResolution is updated "node16" or "nodenext".

Unfortunately this can cause issues with other imported packages. Adding these two fields will allow the package to be used with moduleResolution "node"

[For any environments supporting exports main will be ignored.](https://nodejs.org/api/packages.html#package-entry-points)

> For new packages targeting the currently supported versions of Node.js, the ["exports"](https://nodejs.org/api/packages.html#exports) field is recommended. For packages supporting Node.js 10 and below, the ["main"](https://nodejs.org/api/packages.html#main) field is required. If both ["exports"](https://nodejs.org/api/packages.html#exports) and ["main"](https://nodejs.org/api/packages.html#main) are defined, the ["exports"](https://nodejs.org/api/packages.html#exports) field takes precedence over ["main"](https://nodejs.org/api/packages.html#main) in supported versions of Node.js.
