### PR TITLE
Add types field to package.json to fix type declarations resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"types": "./dist/source/index.d.ts",
 	"exports": {
 		"types": "./dist/source/index.d.ts",
 		"default": "./dist/source/index.js"


### PR DESCRIPTION
After updating from v10.2.0 to v11.0.2  I get the error:

![Bildschirmfoto 2023-10-17 um 14 33 21](https://github.com/sindresorhus/conf/assets/17065920/8f7c1163-c8f6-4521-8179-5a918b8af0b3)


This PR fixes this bug by adding the `types` field in the package.json. This allows VSCode/TS to find the declaration files.


https://github.com/sindresorhus/conf/assets/17065920/5557d895-8e80-48cc-aa8e-b190699c834e

