### PR TITLE
feat: replace buffer with uint8array

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
 		"dot-prop": "^7.2.0",
 		"env-paths": "^3.0.0",
 		"json-schema-typed": "^8.0.1",
-		"semver": "^7.3.8"
+		"semver": "^7.3.8",
+		"uint8array-extras": "^0.2.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^3.0.1",

--- a/readme.md
+++ b/readme.md
@@ -224,7 +224,7 @@ The only use-case I can think of is having the config located in the app directo
 
 #### encryptionKey
 
-Type: `string | Buffer | TypedArray | DataView`\
+Type: `string | Uint8Array | TypedArray | DataView`\
 Default: `undefined`
 
 Note that this is **not intended for security purposes**, since the encryption key would be easily found inside a plain-text Node.js app.

--- a/source/index.ts
+++ b/source/index.ts
@@ -360,7 +360,7 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 
 	private _encryptData(data: string | Uint8Array): string {
 		if (!this.#encryptionKey) {
-			return typeof data === 'string' ? string : uint8ArrayToString(data);
+			return typeof data === 'string' ? data : uint8ArrayToString(data);
 		}
 
 		// Check if an initialization vector has been used to encrypt the data.

--- a/source/index.ts
+++ b/source/index.ts
@@ -360,7 +360,7 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 
 	private _encryptData(data: string | Uint8Array): string {
 		if (!this.#encryptionKey) {
-			return isUint8Array(data) ? uint8ArrayToString(data) : data.toString();
+			return typeof data === 'string' ? string : uint8ArrayToString(data);
 		}
 
 		// Check if an initialization vector has been used to encrypt the data.

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,4 +1,3 @@
-import {type Buffer} from 'node:buffer';
 import {type EventEmitter} from 'node:events';
 import {type JSONSchema as TypedJSONSchema} from 'json-schema-typed';
 // eslint-disable unicorn/import-index
@@ -132,7 +131,7 @@ export type Options<T extends Record<string, any>> = {
 
 	When specified, the store will be encrypted using the [`aes-256-cbc`](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation) encryption algorithm.
 	*/
-	encryptionKey?: string | Buffer | NodeJS.TypedArray | DataView;
+	encryptionKey?: string | Uint8Array | NodeJS.TypedArray | DataView;
 
 	/**
 	Extension of the config file.

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-new, @typescript-eslint/naming-convention */
-import {Buffer} from 'node:buffer';
+import {stringToUint8Array} from 'uint8array-extras';
 import {expectType, expectAssignable, expectError} from 'tsd';
 import Conf from '../source/index.js';
 
@@ -23,7 +23,7 @@ new Conf<UnicornFoo>({configName: ''});
 new Conf<UnicornFoo>({projectName: 'foo'});
 new Conf<UnicornFoo>({cwd: ''});
 new Conf<UnicornFoo>({encryptionKey: ''});
-new Conf<UnicornFoo>({encryptionKey: Buffer.from('')});
+new Conf<UnicornFoo>({encryptionKey: stringToUint8Array('')});
 new Conf<UnicornFoo>({encryptionKey: new Uint8Array([1])});
 new Conf<UnicornFoo>({encryptionKey: new DataView(new ArrayBuffer(2))});
 new Conf<UnicornFoo>({fileExtension: '.foo'});


### PR DESCRIPTION
Fixes #188

This PR replaces usage of `Buffer` in favor of `Uint8Array`. This is done by taking a dependency on the `uint8array-extras` package.

I verified that the tests are passing locally and I have update the documentation in the docstrings & README file.