### PR TITLE
Fix: cannot find module 'conf' in Typescript projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"types": "./dist/source/index.d.ts",
 	"exports": {
 		"types": "./dist/source/index.d.ts",
 		"default": "./dist/source/index.js"


### PR DESCRIPTION
I discovered that Typescript doesn't know where to look for the `conf` type declaration. The issue can be reproduced by creating a new typescript / node project, running `npm install conf`, and importing conf into a ts file without installing `@types/conf`.

Since the `@types/conf` package is now deprecated, I've added a line to the package.json to ensure the declaration file is always found in typescript projects.

![image](https://github.com/sindresorhus/conf/assets/229833/af574422-fde5-427d-a5e7-096afcc6aa11)

The fix is confirmed to solve the issue by running `tsc` to see the import error, adding the types property the package file directly in `node_modules/conf`, and running tsc again to see a successful build.