### PR TITLE
Fix corresponding type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"types": "./dist/source/index.d.ts",
 	"exports": {
 		"types": "./dist/source/index.d.ts",
 		"default": "./dist/source/index.js"


### PR DESCRIPTION
Need to add a "types" field to solve the TS problem
```
TS2307: Cannot find module conf or its corresponding type declarations.
```

It solves issue https://github.com/sindresorhus/electron-store/issues/276