### PR TITLE
fix: store failing validation after schema change

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -146,6 +146,7 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 			this._migrate(options.migrations, options.projectVersion, options.beforeEachMigration);
 		}
 
+		// We defer validation until after migrations are applied so that the store can be updated to the current schema.
 		this._validate(store);
 
 		try {

--- a/source/index.ts
+++ b/source/index.ts
@@ -137,6 +137,15 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 
 		const fileStore = this.store;
 		const store = Object.assign(createPlainObject(), options.defaults, fileStore);
+
+		if (options.migrations) {
+			if (!options.projectVersion) {
+				throw new Error('Please specify the `projectVersion` option.');
+			}
+
+			this._migrate(options.migrations, options.projectVersion, options.beforeEachMigration);
+		}
+
 		this._validate(store);
 
 		try {
@@ -147,14 +156,6 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 
 		if (options.watch) {
 			this._watch();
-		}
-
-		if (options.migrations) {
-			if (!options.projectVersion) {
-				throw new Error('Please specify the `projectVersion` option.');
-			}
-
-			this._migrate(options.migrations, options.projectVersion, options.beforeEachMigration);
 		}
 	}
 


### PR DESCRIPTION
Defer validation until after migrations are applied so that the store can be updated to the current schema.

applies to #187 