### PR TITLE
Add TypeScript overload for `.delete()` to fix dot-notation typing

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -259,6 +259,8 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 	@param key - The key of the item to delete.
 	*/
 	delete<Key extends keyof T>(key: Key): void;
+	// This overload is used for dot-notation access.
+	delete(key: string): void;
 	delete(key: string): void {
 		const {store} = this;
 		if (this.#options.accessPropertiesByDotNotation) {

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -73,6 +73,8 @@ expectType<string>(conf.get('foo'));
 expectType<string>(conf.get('foo', 'bar'));
 conf.delete('foo');
 expectType<boolean>(conf.has('foo'));
+conf.delete('nested.prop');
+expectType<boolean>(conf.has('nested.prop'));
 conf.clear();
 const off = conf.onDidChange('foo', (oldValue, newValue) => {
 	expectAssignable<UnicornFoo[keyof UnicornFoo]>(oldValue);


### PR DESCRIPTION
Fixes / Adds back in original changes from #182

The implementation isn't recognized by TypeScript to be a possible signature for the method, only the overloads will be.

## Changes
* Adds in overload for dot notation
* Adds in type test