### PR TITLE
feat: add `.getAll()` to get all config items

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,8 @@ const config = new Conf({projectName: 'foo'});
 config.set('unicorn', '🦄');
 console.log(config.get('unicorn'));
 //=> '🦄'
-console.log(config.getAll({unicorn: '🦄'}));
-//=> {unicorn: '🦄', foo: {bar: true}}
+console.log(config.getAll());
+//=> {projectName: 'foo', unicorn: '🦄'}
 
 // Use dot-notation to access nested properties
 config.set('foo.bar', true);
@@ -407,9 +407,9 @@ Set multiple items at once.
 
 Get an item or `defaultValue` if the item does not exist.
 
-#### .getAll(defaultValue?)
+#### .getAll()
 
-Get all config items or `defaultValue` if no items exist.
+Get all config items.
 
 #### .reset(...keys)
 

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,8 @@ const config = new Conf({projectName: 'foo'});
 config.set('unicorn', '🦄');
 console.log(config.get('unicorn'));
 //=> '🦄'
+console.log(config.getAll({unicorn: '🦄'}));
+//=> {unicorn: '🦄', foo: {bar: true}}
 
 // Use dot-notation to access nested properties
 config.set('foo.bar', true);
@@ -64,7 +66,7 @@ Type: `object`
 
 [JSON Schema](https://json-schema.org) to validate your config data.
 
-This will be the [`properties`](https://json-schema.org/understanding-json-schema/reference/object.html#properties) object of the JSON schema. That is, define `schema` as an object where each key is the name of your data's property and each value is a JSON schema used to validate that property. 
+This will be the [`properties`](https://json-schema.org/understanding-json-schema/reference/object.html#properties) object of the JSON schema. That is, define `schema` as an object where each key is the name of your data's property and each value is a JSON schema used to validate that property.
 
 Example:
 
@@ -404,6 +406,10 @@ Set multiple items at once.
 #### .get(key, defaultValue?)
 
 Get an item or `defaultValue` if the item does not exist.
+
+#### .getAll(defaultValue?)
+
+Get all config items or `defaultValue` if no items exist.
 
 #### .reset(...keys)
 

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,6 @@ const config = new Conf({projectName: 'foo'});
 config.set('unicorn', '🦄');
 console.log(config.get('unicorn'));
 //=> '🦄'
-console.log(config.getAll());
-//=> {projectName: 'foo', unicorn: '🦄'}
 
 // Use dot-notation to access nested properties
 config.set('foo.bar', true);
@@ -410,6 +408,11 @@ Get an item or `defaultValue` if the item does not exist.
 #### .getAll()
 
 Get all config items.
+
+```js
+console.log(config.getAll());
+//=> {name: '🦄', isUnicorn: true}
+```
 
 #### .reset(...keys)
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -163,24 +163,17 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 	}
 
 	/**
-	Get an item or the entire store.
+	Get an item.
 
-	If no `key` is provided, the entire store object is returned.
-
-	@param key - The key of the item to get. If not provided, the entire store is returned.
-	@param defaultValue - The default value if the item does not exist. Not used if `key` is not provided.
+	@param key - The key of the item to get.
+	@param defaultValue - The default value if the item does not exist.
 	*/
-	get(): T;
 	get<Key extends keyof T>(key: Key): T[Key];
 	get<Key extends keyof T>(key: Key, defaultValue: Required<T>[Key]): Required<T>[Key];
 	// This overload is used for dot-notation access.
 	// We exclude `keyof T` as an incorrect type for the default value should not fall through to this overload.
 	get<Key extends string, Value = unknown>(key: Exclude<Key, keyof T>, defaultValue?: Value): Value;
-	get(key?: string, defaultValue?: unknown): unknown {
-		if (key === undefined) {
-			return this.store;
-		}
-
+	get(key: string, defaultValue?: unknown): unknown {
 		if (this.#options.accessPropertiesByDotNotation) {
 			return this._get(key, defaultValue);
 		}

--- a/source/index.ts
+++ b/source/index.ts
@@ -185,11 +185,9 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 	/**
 	Get all config items.
 
-	@param defaultValue - The default value if no items exist.
 	*/
-	getAll(defaultValue?: T): T {
-		const {store} = this;
-		return Object.keys(store).length === 0 && defaultValue !== undefined ? defaultValue : store;
+	getAll(): T {
+		return this.store || {};
 	}
 
 	/**

--- a/source/index.ts
+++ b/source/index.ts
@@ -163,17 +163,24 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 	}
 
 	/**
-	Get an item.
+	Get an item or the entire store.
 
-	@param key - The key of the item to get.
-	@param defaultValue - The default value if the item does not exist.
+	If no `key` is provided, the entire store object is returned.
+
+	@param key - The key of the item to get. If not provided, the entire store is returned.
+	@param defaultValue - The default value if the item does not exist. Not used if `key` is not provided.
 	*/
+	get(): T;
 	get<Key extends keyof T>(key: Key): T[Key];
 	get<Key extends keyof T>(key: Key, defaultValue: Required<T>[Key]): Required<T>[Key];
 	// This overload is used for dot-notation access.
 	// We exclude `keyof T` as an incorrect type for the default value should not fall through to this overload.
 	get<Key extends string, Value = unknown>(key: Exclude<Key, keyof T>, defaultValue?: Value): Value;
-	get(key: string, defaultValue?: unknown): unknown {
+	get(key?: string, defaultValue?: unknown): unknown {
+		if (key === undefined) {
+			return this.store;
+		}
+
 		if (this.#options.accessPropertiesByDotNotation) {
 			return this._get(key, defaultValue);
 		}

--- a/source/index.ts
+++ b/source/index.ts
@@ -183,6 +183,16 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 	}
 
 	/**
+	Get all config items.
+
+	@param defaultValue - The default value if no items exist.
+	*/
+	getAll(defaultValue?: T): T {
+		const store = this.store;
+		return Object.keys(store).length === 0 && defaultValue !== undefined ? defaultValue : store;
+	}
+
+	/**
 	Set an item or multiple items at once.
 
 	@param {key|object} - You can use [dot-notation](https://github.com/sindresorhus/dot-prop) in a key to access nested properties. Or a hashmap of items to set at once.

--- a/source/index.ts
+++ b/source/index.ts
@@ -184,10 +184,9 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 
 	/**
 	Get all config items.
-
 	*/
 	getAll(): T {
-		return this.store || {};
+		return this.store ?? {};
 	}
 
 	/**

--- a/source/index.ts
+++ b/source/index.ts
@@ -188,7 +188,7 @@ export default class Conf<T extends Record<string, any> = Record<string, unknown
 	@param defaultValue - The default value if no items exist.
 	*/
 	getAll(defaultValue?: T): T {
-		const store = this.store;
+		const {store} = this;
 		return Object.keys(store).length === 0 && defaultValue !== undefined ? defaultValue : store;
 	}
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -69,6 +69,27 @@ test.failing('.get() - `schema` option - default', t => {
 	t.is(store.get('nested.bar'), 55); // See: https://github.com/sindresorhus/electron-store/issues/102
 });
 
+test('.getAll()', t => {
+	const {config} = t.context;
+	t.deepEqual(config.getAll(), {});
+	t.deepEqual(config.getAll({foo: fixture}), {foo: fixture});
+	config.set('foo', fixture);
+	t.deepEqual(config.getAll({baz: '🐴'}), {foo: fixture});
+});
+
+test('.getAll() - with defaults', t => {
+	type Config = {foo: string; bar: string; baz?: string};
+	const store = new Conf<Config>({
+		cwd: temporaryDirectory(),
+		defaults: {
+			foo: fixture,
+			bar: '🐴',
+		},
+	});
+	t.deepEqual(store.getAll(), {foo: fixture, bar: '🐴'});
+	t.deepEqual(store.getAll({foo: fixture, bar: '🐴', baz: 'qux'}), {foo: fixture, bar: '🐴'});
+});
+
 test('.set()', t => {
 	t.context.config.set('foo', fixture);
 	t.context.config.set('baz.boo', fixture);

--- a/test/index.ts
+++ b/test/index.ts
@@ -72,22 +72,9 @@ test.failing('.get() - `schema` option - default', t => {
 test('.getAll()', t => {
 	const {config} = t.context;
 	t.deepEqual(config.getAll(), {});
-	t.deepEqual(config.getAll({foo: fixture}), {foo: fixture});
 	config.set('foo', fixture);
-	t.deepEqual(config.getAll({baz: '🐴'}), {foo: fixture});
-});
-
-test('.getAll() - with defaults', t => {
-	type Config = {foo: string; bar: string; baz?: string};
-	const store = new Conf<Config>({
-		cwd: temporaryDirectory(),
-		defaults: {
-			foo: fixture,
-			bar: '🐴',
-		},
-	});
-	t.deepEqual(store.getAll(), {foo: fixture, bar: '🐴'});
-	t.deepEqual(store.getAll({foo: fixture, bar: '🐴', baz: 'qux'}), {foo: fixture, bar: '🐴'});
+	config.set('bar', '🐴');
+	t.deepEqual(config.getAll(), {foo: fixture, bar: '🐴'});
 });
 
 test('.set()', t => {


### PR DESCRIPTION
Assuming that I have a config like below:

```json
{
  "a": "a",
  "b": "b",
  "c": "c",
  "d": "d"
}
```

To get all configs, I must use `get(xx)` four times. I think maybe it's a good idea to use `get()` to retrieve all configs at one time.
When using `electron`, it can also get all configs with only one disk IO.